### PR TITLE
Avvite name  fix

### DIFF
--- a/data/races/avvim-slaver.txt
+++ b/data/races/avvim-slaver.txt
@@ -46,9 +46,9 @@
 #pose avviteranged
 #pose avvitemage
 
-#longsyllables /data/names/nations/human/longsyllables.txt
-#shortsyllables /data/names/nations/human/shortsyllables.txt
-#suffixes /data/names/nations/human/suffixes.txt
+#longsyllables /data/names/nations/avvite/longsyllables.txt
+#shortsyllables /data/names/nations/avvite/shortsyllables.txt
+#suffixes /data/names/nations/avvite/suffixes.txt
 
 -- Always have shirt
 #generateitem 1 shirt

--- a/data/races/avvim.txt
+++ b/data/races/avvim.txt
@@ -34,9 +34,9 @@
 #pose avviteranged
 #pose avvitemage
 
-#longsyllables /data/names/nations/human/longsyllables.txt
-#shortsyllables /data/names/nations/human/shortsyllables.txt
-#suffixes /data/names/nations/human/suffixes.txt
+#longsyllables /data/names/nations/avvite/longsyllables.txt
+#shortsyllables /data/names/nations/avvite/shortsyllables.txt
+#suffixes /data/names/nations/avvite/suffixes.txt
 
 -- Always have shirt
 #generateitem 1 shirt


### PR DESCRIPTION
They were using human names. Also, I think regular human names might be
better off made germanicish (but distinct from norse and hoburg names)
rather than random gibberish.