### PR TITLE
Theme doc printout fix

### DIFF
--- a/data/items/highmen/cavemen/armor_allied.txt
+++ b/data/items/highmen/cavemen/armor_allied.txt
@@ -1,0 +1,175 @@
+--- Unarmored
+
+#newitem
+#name "starkers"
+#gameid -1
+#needs shirt noshirt
+#armor
+#basechance 0.25
+#theme "primative"
+#theme "naked"
+#enditem
+
+#newitem
+#name "loincloth"
+#gameid -1
+#needs shirt loincloth
+#armor
+#basechance 0.25
+#theme "primative"
+#theme "naked"
+#enditem
+
+
+--- Furs
+
+#newitem
+#name "tight furs"
+#gameid 44
+#sprite /graphics/highmen/armor/furs.png
+#needs shirt noshirt
+#armor
+#basechance 0.5
+#theme "primative"
+#enditem
+
+
+--- Leather
+
+#newitem
+#name "leather cuirass"
+#gameid 5
+#sprite /graphics/highmen/armor/leather2_cuirass.png
+#needs shirt loincloth
+#armor
+#basechance 0.5
+#theme "leather"
+#enditem
+
+#newitem
+#name "leather hauberk"
+#gameid 10
+#sprite /graphics/highmen/armor/leather2_hauberk3.png
+#needs shirt noshirt
+#armor
+#basechance 0.5
+#theme "leather"
+#theme "advanced"
+#enditem
+
+--- Ring
+
+#newitem
+#name "ring cuirass"
+#gameid 6
+#sprite /graphics/highmen/armor/ring2_cuirass.png
+#needs shirt loincloth
+#armor
+#basechance 0.5
+#theme "leather"
+#enditem
+
+#newitem
+#name "ring hauberk"
+#gameid 11
+#sprite /graphics/highmen/armor/ring2_hauberk.png
+#needs shirt noshirt
+#armor
+#basechance 0.5
+#theme "leather"
+#enditem
+
+--- Bronze Scale
+
+#newitem
+#name "bronze scale cuirass"
+#gameid 142
+#sprite /graphics/highmen/armor/scale_cuirass1_bronze.png
+#needs shirt leather
+#armor
+#basechance 0.25
+#theme "bronze"
+#enditem
+
+#newitem
+#name "bronze scale hauberk"
+#gameid 136
+#sprite /graphics/highmen/armor/scale_hauberk_bronze.png
+#needs shirt leather
+#armor
+#basechance 0.25
+#theme "bronze"
+#enditem
+
+
+--- Bronze Plate
+
+#newitem
+#name "bronze plate cuirass"
+#gameid 100
+#sprite /graphics/highmen/armor/plate_cuirass1_bronze.png
+#needs shirt leather
+#armor
+#basechance 0.25
+#theme "bronze"
+#theme "advanced"
+#enditem
+
+#newitem
+#name "bronze plate hauberk"
+#gameid 101
+#sprite /graphics/highmen/armor/plate_hauberk_bronze.png
+#needs shirt leather
+#armor
+#basechance 0.25
+#theme "bronze"
+#theme "advanced"
+#enditem
+
+
+--- Iron Scale
+
+#newitem
+#name "iron scale cuirass"
+#gameid 7
+#sprite /graphics/highmen/armor/scale_cuirass1.png
+#needs shirt leather
+#armor
+#basechance 0.25
+#theme "iron"
+#enditem
+
+#newitem
+#name "iron scale hauberk"
+#gameid 12
+#sprite /graphics/highmen/armor/scale_hauberk.png
+#needs shirt leather
+#armor
+#basechance 0.25
+#theme "iron"
+#enditem
+
+
+--- Iron Plate
+
+#newitem
+#name "iron plate cuirass"
+#gameid 9
+#sprite /graphics/highmen/armor/plate_cuirass1.png
+#needs shirt leather
+#armor
+#basechance 0.25
+#theme "iron"
+#theme "advanced"
+#enditem
+
+#newitem
+#name "iron plate hauberk"
+#gameid 14
+#sprite /graphics/highmen/armor/plate_hauberk.png
+#needs shirt leather
+#armor
+#basechance 0.25
+#theme "iron"
+#theme "advanced"
+#enditem

--- a/data/items/highmen/cavemen/offhand_allied.txt
+++ b/data/items/highmen/cavemen/offhand_allied.txt
@@ -1,0 +1,74 @@
+--- Melee weapons
+#newitem
+#id club
+#gameid 252
+#sprite /graphics/highmen/weapons/offhand_club.png
+#theme "primitive"
+#theme "wood"
+#basechance 1
+#enditem
+
+#newitem
+#id spiked_club
+#gameid 593
+#sprite /graphics/highmen/weapons/offhand_spikedclub.png
+#theme "primitive"
+#theme "wood"
+#basechance 1
+#enditem
+
+#newitem
+#id stone_hatchet
+#gameid 253
+#sprite /graphics/highmen/weapons/offhand_axe.png
+#theme "primitive"
+#basechance 1
+#enditem
+
+#newitem
+#id axe_bronze
+#gameid 17
+#sprite /graphics/highmen/weapons/offhand_axe_bronze.png
+#theme "bronze"
+#basechance 0.25
+#enditem
+
+#newitem
+#id hammer_bronze
+#gameid 13
+#sprite /graphics/highmen/weapons/offhand_hammer_bronze.png
+#theme "bronze"
+#basechance 0.25
+#enditem
+
+#newitem
+#id mace_bronze
+#gameid 12
+#sprite /graphics/highmen/weapons/offhand_mace_bronze.png
+#theme "bronze"
+#basechance 0.25
+#enditem
+
+#newitem
+#id axe_iron
+#gameid 17
+#sprite /graphics/highmen/weapons/offhand_axe.png
+#theme "iron"
+#basechance 0.25
+#enditem
+
+#newitem
+#id hammer_iron
+#gameid 13
+#sprite /graphics/highmen/weapons/offhand_hammer.png
+#theme "iron"
+#basechance 0.25
+#enditem
+
+#newitem
+#id mace_iron
+#gameid 12
+#sprite /graphics/highmen/weapons/offhand_mace.png
+#theme "iron"
+#basechance 0.25
+#enditem

--- a/data/items/highmen/cavemen/shield_allied.txt
+++ b/data/items/highmen/cavemen/shield_allied.txt
@@ -1,0 +1,129 @@
+--- Shields
+
+-- Hide shields
+
+#newitem
+#id hideshield
+#gameid 105
+#sprite /graphics/machakans/shields/hideshield.png
+#offsetx 1
+#offsety -4
+#eliteversion colored_hideshield
+#armor
+#theme "leather"
+#enditem
+
+#newitem
+#id colored_hideshield
+#gameid 105
+#sprite /graphics/machakans/shields/greathideshield.png
+#recolormask /graphics/machakans/shields/greathideshield_recolormask.png
+#offsetx 1
+#offsety -4
+#armor
+#theme "leather"
+#enditem
+
+#newitem
+#id greathideshield
+#gameid 112
+#sprite /graphics/highmen/shields/greathideshield.png
+#recolormask /graphics/highmen/shields/greathideshield_recolormask.png
+#armor
+#theme "leather"
+#enditem
+
+
+-- Bucklers
+
+#newitem
+#id buckler
+#gameid 1
+#sprite /graphics/offhand/standard/shield1.png
+#offsetx 2
+#offsety -1
+#armor
+#theme "wood"
+#enditem
+
+#newitem
+#id bronze_buckler
+#gameid 1
+#sprite /graphics/amazon/shields/targe_burnished.png
+#offsetx 2
+#offsety -2
+#armor
+#theme "bronze"
+#enditem
+
+#newitem
+#id iron_buckler
+#gameid 2
+#sprite /graphics/offhand/standard/shield2.png
+#offsetx 2
+#offsety -1
+#armor
+#theme "iron"
+#enditem
+
+
+-- Normal shields
+
+#newitem
+#id hoplon
+#gameid 2
+#sprite /graphics/amazon/shields/hoplon_burnished.png
+#offsetx 2
+#offsety -2
+#armor
+#theme "bronze"
+#enditem
+
+#newitem
+#id hoplon_painted
+#gameid 2
+#sprite /graphics/amazon/shields/hoplon_bronze.png
+#recolormask /graphics/amazon/shields/hoplon_painted_recolormask.png
+#offsetx 2
+#offsety -2
+#armor
+#enditem
+
+#newitem
+#id iron_shield
+#basechance 1
+#gameid 2
+#sprite /graphics/offhand/standard/shield6.png
+#recolormask /graphics/offhand/standard/shield6_recolormask.png
+#offsetx 2
+#offsety -1
+#armor
+#theme "iron"
+#enditem
+
+
+-- Bonus missiles
+
+#newitem
+#id thrown_rocks
+#gameid 605
+#sprite /graphics/highmen/weapons/offhand_rock.png
+#offsetx 0
+#offsety -1
+#theme "primitive"
+#enditem
+
+#newitem
+#id sticks_and_stones
+#gameid 360
+#theme "primitive"
+#enditem
+
+#newitem
+#id net
+#gameid 263
+#sprite /graphics/highmen/weapons/offhand_net.png
+#basechance 0.25
+#tag "tierunique"
+#tag "name infantry hunter"
+#enditem

--- a/data/items/highmen/cavemen/weapon_allied.txt
+++ b/data/items/highmen/cavemen/weapon_allied.txt
@@ -1,0 +1,234 @@
+-- Primative weapons
+
+#newitem
+#id club
+#gameid 252
+#sprite /graphics/highmen/weapons/club.png
+#offsetx -2
+#offsety 3
+#theme "primitive"
+#theme "wood"
+#tag "name infantry clubber"
+#tag "name infantry tribesman"
+#tag "name commander chieftan"
+#tag "name commander champion"
+#basechance 0.5
+#enditem
+
+#newitem
+#id spiked_club
+#gameid 593
+#sprite /graphics/highmen/weapons/spikedclub.png
+#offsetx -2
+#offsety 3
+#theme "primitive"
+#theme "wood"
+#tag "name infantry clubber"
+#tag "name infantry tribesman"
+#tag "name commander chieftan"
+#tag "name commander champion"
+#basechance 0.5
+#enditem
+
+#newitem
+#id great_club
+#gameid 165
+#sprite /graphics/highmen/weapons/greatclub.png
+#offsetx 0
+#offsety 3
+#needs hands hands_2h
+#theme "primitive"
+#theme "wood"
+#tag "name infantry warrior"
+#tag "name infantry tribesman"
+#tag "name commander chieftan"
+#basechance 1
+#enditem
+
+#newitem
+#id stone_spear
+#gameid 373
+#sprite /graphics/highmen/weapons/spear.png
+#offsetx -2
+#offsety 2
+#needs hands hands_2h
+#theme "primitive"
+#tag "name infantry hunter"
+#tag "name commander chieftan"
+#tag "name commander champion"
+#basechance 1
+#enditem
+
+#newitem
+#id stone_hatchet
+#gameid 253
+#sprite /graphics/highmen/weapons/axe.png
+#offsetx -3
+#offsety 3
+#theme "primitive"
+#tag "name infantry warrior"
+#tag "name infantry tribesman"
+#tag "name commander chieftan"
+#tag "name commander champion"
+#basechance 1
+#enditem
+
+
+-- "Advanced" weapons
+
+#newitem
+#id axe_bronze
+#gameid 17
+#sprite /graphics/highmen/weapons/axe_bronze.png
+#offsetx -3
+#offsety 3
+#theme "bronze"
+#tag "name infantry axeman"
+#tag "name infantry warrior"
+#tag "name commander champion"
+#tag "name commander warchief"
+#basechance 0.25
+#enditem
+
+#newitem
+#id greataxe_bronze
+#gameid 18
+#sprite /graphics/highmen/weapons/battleaxe_bronze.png
+#offsetx -2
+#offsety 2
+#needs hands hands_2h
+#theme "bronze"
+#tag "name infantry axeman"
+#tag "name infantry warrior"
+#tag "name commander champion"
+#tag "name commander warchief"
+#basechance 0.25
+#enditem
+
+#newitem
+#id hammer_bronze
+#gameid 13
+#sprite /graphics/highmen/weapons/hammer_bronze.png
+#offsetx -3
+#offsety 3
+#theme "bronze"
+#tag "name infantry hammerer"
+#tag "name infantry warrior"
+#tag "name commander champion"
+#tag "name commander warchief"
+#basechance 0.25
+#enditem
+
+#newitem
+#id mace_bronze
+#gameid 12
+#sprite /graphics/highmen/weapons/mace_bronze.png
+#offsetx -3
+#offsety 3
+#theme "bronze"
+#tag "name infantry maceman"
+#tag "name infantry warrior"
+#tag "name commander champion"
+#tag "name commander warchief"
+#basechance 0.25
+#enditem
+
+#newitem
+#id axe_iron
+#gameid 17
+#sprite /graphics/highmen/weapons/axe_iron.png
+#offsetx -3
+#offsety 3
+#theme "iron"
+#tag "name infantry axeman"
+#tag "name infantry warrior"
+#tag "name commander champion"
+#tag "name commander warchief"
+#basechance 0.25
+#enditem
+
+#newitem
+#id greataxe_iron
+#gameid 18
+#sprite /graphics/highmen/weapons/battleaxe_iron.png
+#offsetx -2
+#offsety 2
+#needs hands hands_2h
+#theme "iron"
+#tag "name infantry axeman"
+#tag "name infantry warrior"
+#tag "name commander champion"
+#tag "name commander warchief"
+#basechance 0.25
+#enditem
+
+#newitem
+#id hammer_iron
+#gameid 13
+#sprite /graphics/highmen/weapons/hammer_iron.png
+#offsetx -3
+#offsety 3
+#theme "iron"
+#tag "name infantry hammerer"
+#tag "name infantry warrior"
+#tag "name commander champion"
+#tag "name commander warchief"
+#basechance 0.25
+#enditem
+
+#newitem
+#id mace_iron
+#gameid 12
+#sprite /graphics/highmen/weapons/mace_iron.png
+#offsetx -3
+#offsety 3
+#theme "iron"
+#tag "name infantry maceman"
+#tag "name infantry warrior"
+#tag "name commander champion"
+#tag "name commander warchief"
+#basechance 0.25
+#enditem
+
+#newitem
+#id maul
+#gameid 14
+#sprite /graphics/highmen/weapons/maul.png
+#offsetx -2
+#offsety 2
+#needs hands hands_2h
+#tag "name infantry hammerer"
+#tag "name infantry warrior"
+#tag "name commander champion"
+#tag "name commander warchief"
+#basechance 1
+#enditem
+
+#newitem
+#id spear
+#gameid 1
+#sprite /graphics/highmen/weapons/spear.png
+#offsetx -2
+#offsety 2
+#needs hands hands_2h
+#theme "wood"
+#tag "name infantry hunter"
+#tag "name commander chieftan"
+#tag "name commander champion"
+#basechance 1
+#enditem
+
+#newitem
+#id quarterstaff
+#gameid 7
+#sprite /graphics/highmen/weapons/quarterstaff.png
+#offsetx -2
+#offsety 2
+#needs hands hands_2h
+#theme "wood"
+#tag "name infantry warrior"
+#tag "name commander champion"
+#tag "name commander warchief"
+#basechance 0.25
+#maxprot 10
+#enditem

--- a/data/items/hoburg/crossbow/weapon.txt
+++ b/data/items/hoburg/crossbow/weapon.txt
@@ -28,7 +28,7 @@
 #theme "iron"
 #basechance 0.25
 #define "#gcost +1"
-#define "#rcost +5"
+#define "#rcost +3"
 #enditem
 
 #newitem

--- a/data/poses/highmen/cavemanallies.txt
+++ b/data/poses/highmen/cavemanallies.txt
@@ -1,0 +1,52 @@
+
+-------- Normal
+
+#newpose
+#name "caveman auxilliary"
+#role "infantry"
+#role "scout"
+#role "sacred infantry"
+#role "elite infantry"
+
+#load basesprite /data/items/highmen/cavemen/bases.txt
+#load shadow /data/items/highmen/cavemen/shadow.txt
+#load hands /data/items/highmen/cavemen/hands.txt
+
+#load armor /data/items/highmen/cavemen/armor_allied.txt
+#load shirt /data/items/highmen/cavemen/shirt.txt
+
+#load weapon /data/items/highmen/cavemen/weapon_allied.txt
+#load offhand /data/items/highmen/cavemen/offhand_allied.txt
+#load offhand /data/items/highmen/cavemen/shield_allied.txt
+
+#maxunits 3
+
+#endpose
+
+
+---------- Mages and Priests
+
+#newpose
+#name "caveman shaman"
+#role "mage"
+#role "priest"
+
+#tier 1
+#notfortier 2
+#notfortier 3
+
+#renderorder "shadow bonusweapon cloakb basesprite armor cloakf weapon offhand hands hair helmet"
+
+#load basesprite /data/items/highmen/cavemen/bases.txt
+#load shadow /data/items/highmen/cavemen/shadow.txt
+#load hands /data/items/highmen/cavemen/hands.txt
+
+#load armor /data/items/highmen/cavemen/armor_caster.txt
+#load shirt /data/items/highmen/cavemen/shirt.txt
+
+#load weapon /data/items/highmen/cavemen/weapon_caster.txt
+#load offhand /data/items/highmen/cavemen/offhand_caster.txt
+
+#load helmet /data/items/highmen/cavemen/helmet_caster.txt
+
+#endpose

--- a/data/poses/poses.txt
+++ b/data/poses/poses.txt
@@ -34,6 +34,7 @@
 ---- Assorted "high men" - old, big humanish races like cavemen and sleepers
 #load cavemantroops ./data/poses/highmen/cavemantroops.txt
 #load cavemanmages ./data/poses/highmen/cavemanmages.txt
+#load cavemanallies ./data/poses/highmen/cavemanallies.txt
 #load sleepertroops ./data/poses/highmen/sleepertroops.txt
 
 ---- Lizard poses

--- a/data/poses/sobek/sobekmage.txt
+++ b/data/poses/sobek/sobekmage.txt
@@ -22,10 +22,8 @@
 #tier 3
 #notfortier 2
 #notfortier 1
-#endpose
 
 #endpose
-
 
 
 #newpose
@@ -49,6 +47,5 @@
 #notfortier 3
 #tier 2
 #notfortier 1
-#endpose
 
 #endpose

--- a/data/themes/hoburg_themes.txt
+++ b/data/themes/hoburg_themes.txt
@@ -21,9 +21,10 @@
 #themeinc theme leather *2
 #themeinc theme naked *2
 #themeinc theme primitive *2
-#racedefinition "#unitcommand '#gcost -2'"
+#racedefinition "#unitcommand '#gcost -1'"
 #racedefinition "#unitcommand '#mor -1'"
 #racedefinition "#unitcommand '#str -1'"
+#racedefinition "#unitcommand '#def +1'"
 #racedefinition "#unitcommand '#prec -2'"
 #racedefinition "#unitcommand '#enc -1'"
 #racedefinition "#unitcommand '#mapmove +1'"
@@ -52,6 +53,8 @@
 #themeinc theme naked *1
 #themeinc theme primitive *1
 #racedefinition "#unitcommand '#gcost -1'"
+#racedefinition "#unitcommand '#mor -1'"
+#racedefinition "#unitcommand '#def +1'
 #racedefinition "#magicpriority nature 5"
 #racedefinition "#pose hoburgmages"
 #racedefinition "#pose hoburgtroops"
@@ -223,4 +226,19 @@
 #racedefinition "#longsyllables /data/names/nations/amazon/longsyllables.txt"
 #racedefinition "#shortsyllables /data/names/nations/amazon/shortsyllables.txt"
 #racedefinition "#unitcommand '#nametype 107'"
+#endtheme
+
+
+--- Social themes
+
+#newtheme
+#type social
+#name cavemen_allies
+#basechance 0.5
+#chanceinc racetheme primitive *2
+#chanceinc racetheme agrarian *2
+#chanceinc racetheme advanced *0.5
+#chanceinc racetheme industrial *0.1
+#racedefinition "#pose cavemanallies"
+#racedefinition "#tag 'preferredmount caveman'"
 #endtheme

--- a/src/nationGen/nation/Nation.java
+++ b/src/nationGen/nation/Nation.java
@@ -723,8 +723,8 @@ public class Nation {
         tw.println("-- Nation " + nationid + ": " + this.name + ", " + this.epithet);
         tw.println("---------------------------------------------------------------");
         tw.println("-- Generated with filters: " + this.appliedfilters);
-        tw.println("-- Generated with " + races.get(0) + " race themes: " + races.get(0).themes);
-        tw.println("-- Generated with " + races.get(1) + " race themes: " + races.get(1).themes);
+        tw.println("-- Generated with " + races.get(0) + " race themes: " + races.get(0).themefilters);
+        tw.println("-- Generated with " + races.get(1) + " race themes: " + races.get(1).themefilters);
         tw.println("---------------------------------------------------------------");
 
         //writeNationInfo(tw);


### PR DESCRIPTION
-Themes used weren't printing out in the .dm because it was trying to
print race(X).themes instead of race(X).themefilters
- Added caveman_allies social theme for hoburgs to give them
better-equipped caveman allies w/in the primary race and a preference
for cavemen mounts
- Tweaks to lower-tech hoburg stats (+1 def / -1 mor)