### PR TITLE
Gods, ally preferences, hoburg golem cults

### DIFF
--- a/data/misc/gods-austral.txt
+++ b/data/misc/gods-austral.txt
@@ -1,0 +1,46 @@
+--- You don't need to define the shapeshifting commands, they are done automatically based on the filter applying the shapes
+
+
+#new god
+#name "celtic"
+#command "#homerealm 2"
+#basechance 0.5
+#end
+
+#new god
+#name "mediterranean"
+#command "#homerealm 3"
+#basechance 8
+#end
+
+#new god
+#name "far east"
+#command "#homerealm 4"
+#basechance 0.5
+#end
+
+#new god
+#name "middle east"
+#command "#homerealm 5"
+#basechance 4
+#end
+
+#new god
+#name "middle america"
+#command "#homerealm 6"
+#basechance 4
+#end
+
+#new god
+#name "africa"
+#command "#homerealm 7"
+#basechance 20
+#end
+
+#new god
+#name "india"
+#command "#homerealm 8"
+#basechance 4
+#end
+
+

--- a/data/misc/gods-occidental.txt
+++ b/data/misc/gods-occidental.txt
@@ -1,0 +1,45 @@
+--- You don't need to define the shapeshifting commands, they are done automatically based on the filter applying the shapes
+
+#new god
+#name "north"
+#command "#homerealm 1"
+#basechance 5
+#end
+
+#new god
+#name "celtic"
+#command "#homerealm 2"
+#basechance 2
+#end
+
+#new god
+#name "mediterranean"
+#command "#homerealm 3"
+#basechance 0.5
+#end
+
+#new god
+#name "far east"
+#command "#homerealm 4"
+#basechance 2
+#end
+
+#new god
+#name "middle america"
+#command "#homerealm 6"
+#basechance 20
+#end
+
+#new god
+#name "africa"
+#command "#homerealm 7"
+#basechance 10
+#end
+
+#new god
+#name "india"
+#command "#homerealm 8"
+#basechance 0.5
+#end
+
+

--- a/data/misc/gods-oriental.txt
+++ b/data/misc/gods-oriental.txt
@@ -1,0 +1,46 @@
+--- You don't need to define the shapeshifting commands, they are done automatically based on the filter applying the shapes
+
+#new god
+#name "north"
+#command "#homerealm 1"
+#basechance 2
+#end
+
+
+#new god
+#name "celtic"
+#command "#homerealm 2"
+#basechance 0.25
+#end
+
+#new god
+#name "mediterranean"
+#command "#homerealm 3"
+#basechance 2
+#end
+
+#new god
+#name "far east"
+#command "#homerealm 4"
+#basechance 20
+#end
+
+#new god
+#name "middle east"
+#command "#homerealm 5"
+#basechance 5
+#end
+
+#new god
+#name "africa"
+#command "#homerealm 7"
+#basechance 0.25
+#end
+
+#new god
+#name "india"
+#command "#homerealm 8"
+#basechance 10
+#end
+
+

--- a/data/misc/miscdef.txt
+++ b/data/misc/miscdef.txt
@@ -5,6 +5,9 @@
 #load agarthagods ./data/misc/gods-agartha.txt
 #load lizardgods ./data/misc/gods-lizard.txt
 #load monkeygods ./data/misc/gods-monkey.txt
+#load easterngods ./data/misc/gods-oriental.txt
+#load westerngods ./data/misc/gods-occidental.txt
+#load southerngods ./data/misc/gods-austral.txt
 
 --- Individual gods
 

--- a/data/races/agarthans.txt
+++ b/data/races/agarthans.txt
@@ -35,6 +35,8 @@
 #specialcommand "#def +1"
 #specialcommand "#prec +1"
 
+#nationcommand "#uwbuild 1"
+
 #pose agarthantroops
 #pose agarthanmages
 
@@ -45,6 +47,9 @@
 
 #secondaryracecommand_conditional "#darkvision +50"
 
+#chanceinc primaryrace zotz *2
+#chanceinc primaryrace muuch *2
+#chanceinc primaryrace abysian *2
 
 #generationchance cavalry 0.075
 #sacredcavalrychance 0.075

--- a/data/races/atlantian.txt
+++ b/data/races/atlantian.txt
@@ -2,7 +2,6 @@
 #name "Atlantian"
 #basechance 0.2
 #all_troops_elite
-#poses /races/atlantian/poses.txt
 
 #longsyllables /data/names/nations/atlantian/longsyllables.txt
 #shortsyllables /data/names/nations/atlantian/shortsyllables.txt
@@ -22,6 +21,10 @@
 
 #pose atlantiantroops
 #pose atlantianmages
+
+#nationcommand "#uwbuild 1"
+
+#chanceinc primaryrace muuch *2
 
 #magicpriority water 10
 #monsterchance 0.01

--- a/data/races/caelians.txt
+++ b/data/races/caelians.txt
@@ -31,10 +31,6 @@
 #chanceinc "primaryrace lizard *0.25"
 #chanceinc "primaryrace abysian *0.125"
 #chanceinc "primaryrace van *2"
-#chanceinc "primaryrace 'Lizard slavers' *0.1"
-#chanceinc "primaryrace 'Abysian slavers' *0.05"
-#chanceinc "primaryrace 'Van slavers' *0.5"
-#chanceinc "primaryrace 'Avvite slavers' *0.1"
 
 #monsterchance 0.75
 

--- a/data/races/cavemen.txt
+++ b/data/races/cavemen.txt
@@ -34,10 +34,6 @@
 #chanceinc "primaryrace Zotz *7.5"
 #chanceinc "primaryrace Muuch *7.5"
 #chanceinc "primaryrace Abysian *7.5"
-#chanceinc "primaryrace 'Lizard slavers' *5"
-#chanceinc "primaryrace 'Avvite slavers' *15"
-#chanceinc "primaryrace 'Abysian slavers' *15"
-#chanceinc "primaryrace 'Van slavers' *2"
 
 #weakmagicpatterns
 

--- a/data/races/fomorians.txt
+++ b/data/races/fomorians.txt
@@ -7,8 +7,6 @@
 #pose fomorianmages
 #pose fomoriangiants
 
-
-
 #longsyllables /data/names/nations/fomorian/longsyllables.txt
 #shortsyllables /data/names/nations/fomorian/shortsyllables.txt
 #suffixes /data/names/nations/fomorian/suffixes.txt

--- a/data/races/ichtyid.txt
+++ b/data/races/ichtyid.txt
@@ -2,7 +2,6 @@
 #name "Ichtyid"
 #basechance 0.1
 #all_troops_elite
-#poses /races/ichtyid/poses.txt
 
 -- Mimicing Atlantian names because we don't have anything else for ichtyids right now
 #longsyllables /data/names/nations/atlantian/longsyllables.txt
@@ -24,13 +23,14 @@
 #unitcommand "#nametype 117"
 #unitcommand "#maxage 50"
 
+#nationcommand "#uwbuild 1"
+
 #pose ichtyidtroops
 #pose ichtyidmages
 
 #magicpriority water 6
 #magicpriority nature 4
 #monsterchance 0.01
-
 
 #description "Ichtyids are a race of fishmen that dwell along that dwell along the coastlines, both in the water and on land."
 

--- a/data/races/machakans.txt
+++ b/data/races/machakans.txt
@@ -22,8 +22,10 @@
 #nationcommand "#idealcold -1"
 
 #chanceinc "race lizard *3"
-#chanceinc "primaryrace Sobek *3"
 
 #mapmovepenaltyenc 3
 #mapmovepenaltyamount 2
+
+#gods southerngods
+
 #endrace

--- a/data/races/muuch.txt
+++ b/data/races/muuch.txt
@@ -23,7 +23,11 @@
 #unitcommand "#maxage 500"
 
 #nationcommand "#idealcold -1"
+#nationcommand "#uwbuild 1"
+
 #generationchance ranged 0.125
+
+#gods westerngods
 
 #pose muuchtroops
 #pose muuchmages
@@ -37,6 +41,7 @@
 #chanceinc era 3 *2
 
 #chanceinc primaryrace agarthan *2
+#chanceinc primaryrace abysian *2
 #chanceinc primaryrace Atlantian *10
 #chanceinc primaryrace zotz *15
 

--- a/data/races/orientalhuman.txt
+++ b/data/races/orientalhuman.txt
@@ -16,4 +16,7 @@
 
 #unitcommand "#nametype 134"
 #tag "preferredmount horse"
+
+#gods easterngods
+
 #endrace

--- a/data/races/sidhe.txt
+++ b/data/races/sidhe.txt
@@ -50,9 +50,6 @@
 #chanceinc "primaryrace abysian *0.1"
 #chanceinc "primaryrace hoburg *6"
 #chanceinc "primaryrace human *2"
-#chanceinc "primaryrace 'Lizard slavers' *0.1"
-#chanceinc "primaryrace 'Abysian slavers' *0.01"
-#chanceinc "primaryrace 'Van slavers' *0.5"
 
 #chanceinc era 1 *3
 #chanceinc era 3 *0.5

--- a/data/races/tengu.txt
+++ b/data/races/tengu.txt
@@ -24,10 +24,8 @@
 #secondary
 #specialcommand "#weapon 419 -- Lighting Strike (racial)"
 
-#chanceinc "primaryrace 'Lizard slavers' *0.01"
-#chanceinc "primaryrace 'Abysian slavers' *0.01"
-#chanceinc "primaryrace 'Van slavers' *0.01"
 #chanceinc "primaryrace caelian *20"
+#chanceinc "primaryrace 'Oriental human' *10"
 
 #all_troops_sacred
 #all_troops_elite

--- a/data/races/vanir.txt
+++ b/data/races/vanir.txt
@@ -42,7 +42,6 @@
 
 #chanceinc "hasprimaryrace 0.225"
 #chanceinc "primaryrace abysian *0.1"
-#chanceinc "primaryrace humanbred *0.2"
 #chanceinc "primaryrace caelian *4"
 #chanceinc "primaryrace human *2"
 #chanceinc "primaryrace vaetti *0.5"

--- a/data/races/zotz.txt
+++ b/data/races/zotz.txt
@@ -33,6 +33,8 @@
 
 #nationcommand "#idealcold -1"
 
+#gods westerngods
+
 #longsyllables /data/names/nations/nahuatl/longsyllables.txt
 #shortsyllables /data/names/nations/nahuatl/shortsyllables.txt
 #suffixes /data/names/nations/nahuatl/suffixes.txt
@@ -43,6 +45,8 @@
 #magicpriority earth 4
 
 #chanceinc primaryrace agarthan *2
+#chanceinc primaryrace abysian *2
+#chanceinc primaryrace atlantian *2
 #chanceinc primaryrace muuch *10
 
 #all_troops_elite

--- a/data/templates/sloth_magetemplate.txt
+++ b/data/templates/sloth_magetemplate.txt
@@ -1,0 +1,8 @@
+
+#new
+#name "slave"
+#type slave
+#command "#slave"
+#command "#mor -1"
+#theme slave
+#end

--- a/data/templates/templates.txt
+++ b/data/templates/templates.txt
@@ -6,3 +6,4 @@
 #load default_magetemplates ./data/templates/default_magetemplates.txt
 
 #load slavetemplate ./data/templates/slavetemplate.txt
+#load sloth_magetemplates ./data/templates/sloth_magetemplates.txt

--- a/data/themes/hoburg_themes.txt
+++ b/data/themes/hoburg_themes.txt
@@ -13,6 +13,7 @@
 #basechance 0.5
 #chanceinc era 3 -0.25
 #chanceinc era 1 +1
+#chanceinc primaryrace 'Human (advanced)' *0.25
 #themeinc theme mechanical *0.05
 #themeinc theme advanced *0.05
 #themeinc theme iron *0.05
@@ -44,6 +45,7 @@
 #name agrarian
 #basechance 1
 #chanceinc era 3 -0.5
+#chanceinc primaryrace 'Human (advanced)' *0.5
 #themeinc theme mechanical *0.05
 #themeinc theme advanced *0.25
 #themeinc theme iron *1
@@ -70,6 +72,7 @@
 #basechance 0.25
 #chanceinc era 3 1.75
 #chanceinc era 2 0.75
+#chanceinc primaryrace 'Human (advanced)' *4
 #themeinc theme mechanical +0.25
 #themeinc theme advanced *2
 #themeinc theme iron *2
@@ -93,6 +96,7 @@
 #basechance 0.05
 #chanceinc era 3 *20
 #chanceinc era 2 *6
+#chanceinc primaryrace 'Human (advanced)' *2
 #themeinc theme mechanical +1
 #themeinc theme mechanical *2
 #themeinc theme advanced *3
@@ -135,6 +139,7 @@
 #themeinc theme naked *0.5
 #themeinc theme primitive *1
 #racedefinition "#nationcommand '#idealcold +1'"
+#racedefinition "#nationcommand '#gods europegods"
 #endtheme
 
 --"Asian neo-Jomonese" hoburgs 
@@ -147,6 +152,10 @@
 #chanceinc racetheme agrarian *1
 #chanceinc racetheme advanced *2
 #chanceinc racetheme industrial *2
+#chanceinc primaryrace 'Oriental human' *5
+#chanceinc primaryrace ape *2.5
+#chanceinc primaryrace zotz *0.5
+#chanceinc primaryrace muuch *0.5
 #themeinc theme mechanical *2
 #themeinc theme advanced *1
 #themeinc theme iron *2
@@ -160,6 +169,7 @@
 #racedefinition "#longsyllables /data/names/nations/oriental/longsyllables.txt"
 #racedefinition "#shortsyllables /data/names/nations/oriental/shortsyllables.txt"
 #racedefinition "#unitcommand '#nametype 134'"
+#racedefinition "#nationcommand '#gods easterngods"
 #endtheme
 
 --"Mesoamerican proto-Mictlanese" hoburgs 
@@ -172,6 +182,10 @@
 #chanceinc racetheme agrarian *1
 #chanceinc racetheme advanced *0.5
 #chanceinc racetheme industrial *0.25
+#chanceinc primaryrace 'Oriental human' *0.5
+#chanceinc primaryrace ape *0.5
+#chanceinc primaryrace zotz *5
+#chanceinc primaryrace muuch *5
 #themeinc theme mechanical *0.25
 #themeinc theme advanced *0.25
 #themeinc theme iron *0.25
@@ -186,6 +200,7 @@
 #racedefinition "#shortsyllables /data/names/nations/nahuatl/shortsyllables.txt"
 #racedefinition "#unitcommand '#nametype 123'"
 #racedefinition "#nationcommand '#idealcold -1'"
+#racedefinition "#nationcommand '#gods westerngods"
 #endtheme
 
 -- "African quasi-Machakan" hoburgs 
@@ -198,6 +213,11 @@
 #chanceinc racetheme agrarian *1
 #chanceinc racetheme advanced *1
 #chanceinc racetheme industrial *0.5
+#chanceinc primaryrace 'Human (black)' *5
+#chanceinc primaryrace Lizard *2.5
+#chanceinc primaryrace Avvite *2.5
+#chanceinc primaryrace van *0.5
+#chanceinc primaryrace vaetti *0.5
 #themeinc theme mechanical *0.25
 #themeinc theme advanced *1
 #themeinc theme iron *2
@@ -212,6 +232,7 @@
 #racedefinition "#shortsyllables /data/names/nations/machakan/shortsyllables.txt"
 #racedefinition "#unitcommand '#nametype 126'"
 #racedefinition "#nationcommand '#idealcold -1'"
+#racedefinition "#nationcommand '#gods southerngods"
 #endtheme
 
 -- "Hellenic quasi-Arco" hoburgs 
@@ -224,6 +245,12 @@
 #chanceinc racetheme agrarian *2
 #chanceinc racetheme advanced *2
 #chanceinc racetheme industrial *0.25
+#chanceinc primaryrace 'Human (Amazon)' *5
+#chanceinc primaryrace Minotaur *5
+#chanceinc primaryrace Lizard *2
+#chanceinc primaryrace Avvite *2
+#chanceinc primaryrace zotz *0.5
+#chanceinc primaryrace muuch *0.5
 #themeinc theme mechanical *2
 #themeinc theme advanced *0.5
 #themeinc theme iron *1
@@ -288,4 +315,32 @@
 #racedefinition "#unitcommand '#forestsurvival'"
 #racedefinition "#unitcommand '#illusion'"
 #racedefinition "#unitcommand '#nametype 142'"
+#endtheme
+
+-- Weights: primitive 0.01, agrarian 0.2, advanced 0.2, industrial 0.4
+#newtheme
+#type social
+#name lesser_golem_cult
+#basechance 0.1
+#chanceinc racetheme primitive *0.1
+#chanceinc racetheme agrarian *2
+#chanceinc racetheme advanced *2
+#chanceinc racetheme industrial *4
+#themeinc theme mechanical *2
+#racedefinition "#nationcommand '#golemhp 5'"
+#racedefinition "#magicpriority earth 8"
+#endtheme
+
+-- Weights: primitive 0.005, agrarian 0.1, advanced 0.1, industrial 0.2
+#newtheme
+#type social
+#name greater_golem_cult
+#basechance 0.05
+#chanceinc racetheme primitive *0.1
+#chanceinc racetheme agrarian *2
+#chanceinc racetheme advanced *2
+#chanceinc racetheme industrial *4
+#themeinc theme mechanical *3
+#racedefinition "#nationcommand '#golemhp 10'"
+#racedefinition "#magicpriority earth 10"
 #endtheme

--- a/src/nationGen/naming/Summary.java
+++ b/src/nationGen/naming/Summary.java
@@ -538,6 +538,7 @@ public class Summary {
 		int templecost = 400;
 		int labcost = 500;
 		int fortcost = 0;
+		int golemcult = 0;
 		for(Command c : n.commands)
 		{
 			if(c.command.equals("#nopreach"))
@@ -548,6 +549,8 @@ public class Summary {
 				bloodsac = true;
 			if(c.command.equals("#manikinreanim"))
 				manikin = true;
+			if(c.command.equals("#golemhp"))
+				golemcult = Integer.parseInt(c.args.get(0));
 			if(c.command.equals("#templecost"))
 				templecost = Integer.parseInt(c.args.get(0));
 			if(c.command.equals("#labcost"))
@@ -590,6 +593,8 @@ public class Summary {
 			priest = priest + ", can perform blood sacrifices";
 		if(manikin)
 			priest = priest + ", can reanimate manikin";
+		if(golemcult > 0)
+			priest = priest + ", their constructs are stronger within their Dominion";
 		
 		priest = priest + ".";
 		


### PR DESCRIPTION
- Defined "western", "eastern", and "southern" homerealm preferences,
and added them to a couple of races and hoburg regional themes
- Added a few more chanceincs based on primaryrace for secondary races
and hoburg regional themes
- Added "#nationcommand '#uwbuild 1'" to the four amphibious races
- Added relatively low-probability hoburg social themes for 5%/10% golem
cults; added handling to output a line describing nations with #golemhp
in Summary.java