### PR TITLE
default_trooptemplates fix

### DIFF
--- a/data/templates/default_trooptemplates.txt
+++ b/data/templates/default_trooptemplates.txt
@@ -212,7 +212,7 @@
 #maxvarieties 2
 #maxunits 2
 #chanceinc pose chariot *0
-#command "#patrolbonus 1 +1"
+#command "#patrolbonus +1"
 #generateitem 0.25 cloakb
 #end
 
@@ -225,7 +225,7 @@
 #maxunits 2
 #chanceinc pose mounted *0
 #chanceinc pose chariot *0
-#command "#castledef 1"
+#command "#castledef +1"
 #generateitem 0.25 cloakb
 #theme guard
 #end


### PR DESCRIPTION
- malformed argument in patroller 1 template was causing index
out-of-bounds errors