### PR TITLE
 	Minotaurs labeled as a subrace

### DIFF
--- a/data/poses/gaian/minotaurmages.txt
+++ b/data/poses/gaian/minotaurmages.txt
@@ -6,6 +6,8 @@
 #role "mage"
 #role "priest"
 
+#subrace "minotaur"
+
 #load basesprite /data/items/gaian/minotaur/bases_caster.txt
 #load shadow /data/items/gaian/minotaur/shadow.txt
 #load hands /data/items/gaian/minotaur/hafted_hands.txt
@@ -32,6 +34,8 @@
 #name "tier 2-3 mature elder"
 #role "mage"
 #role "priest"
+
+#subrace "minotaur"
 
 #renderorder "shadow weapon cloakb basesprite armor bonusweapon offhandw hands cloakf helmet offhanda"
 

--- a/data/poses/gaian/minotaurtroops.txt
+++ b/data/poses/gaian/minotaurtroops.txt
@@ -9,6 +9,8 @@
 #basedchance 2
 #theme "savage"
 
+#subrace "minotaur"
+
 #command "#trample"
 
 #load basesprite /data/items/gaian/minotaur/bases.txt
@@ -36,6 +38,8 @@
 
 #basedchance 0.5
 #theme "savage"
+
+#subrace "minotaur"
 
 #command "#trample"
 
@@ -66,6 +70,8 @@
 
 #basechance 3
 
+#subrace "minotaur"
+
 #command "#trample"
 
 #load basesprite /data/items/gaian/minotaur/2h_bases.txt
@@ -94,6 +100,8 @@
 
 #basedchance 1
 #theme "civilized"
+
+#subrace "minotaur"
 
 #command "#trample"
 #command "#def +1"
@@ -127,6 +135,8 @@
 
 #basedchance 0.5
 #theme "civilized"
+
+#subrace "minotaur"
 
 #command "#formationfighter +1"
 #command "#mor +1"


### PR DESCRIPTION
Gave all minotaur poses a subrace tag; right now it would be easier to
just get rid of the #visiblename, but aesthetically I'd rather have them
as a subrace of the collective glob of pan-Gaian races regardless of
whether saytrs and centaurs end up being added as demographic themes for
a single overarching Gaian race alongside minotaurs, or as separate
races that tend to ally with each other