### PR TITLE
Internal name format consistency for human subraces

### DIFF
--- a/data/filters/default_nationfilters.txt
+++ b/data/filters/default_nationfilters.txt
@@ -478,7 +478,7 @@
 #basechance 0
 #command "#guardspirit 396"
 #chanceinc primaryrace human 0.0125
-#chanceinc primaryrace "Human (advanced)" 0.0125
+#chanceinc primaryrace "Advanced human" 0.0125
 #desc "Nuns occasionally follow priests in battles"
 #end
 

--- a/data/items/abysian/humanbred/humanmounts.txt
+++ b/data/items/abysian/humanbred/humanmounts.txt
@@ -367,7 +367,7 @@
 #offsetx -1
 #tag "animal lion"
 #tag "guaranteedprefix lion"
-#chanceinc primaryrace "human (black)" *10
+#chanceinc primaryrace "Austral human" *10
 #enditem
 
 #newitem

--- a/data/items/amazon/mounted/amazonmounts.txt
+++ b/data/items/amazon/mounted/amazonmounts.txt
@@ -26,7 +26,7 @@
 #tag "animal gryphon"
 #tag "guaranteedprefix gryphon"
 #basechance 0.2
-#chanceinc primaryrace "Human (Amazon)" *5
+#chanceinc primaryrace "Amazon human" *5
 #sacredextra 0.8
 #enditem
 
@@ -52,7 +52,7 @@
 #theme "specialmount"
 #tag "animal leogryph"
 #tag "guaranteedprefix leogryph"
-#chanceinc primaryrace "Human (Amazon)" *5
+#chanceinc primaryrace "Amazon human" *5
 #enditem
 
 #newitem
@@ -83,7 +83,7 @@
 #tag "eliteversion equine_nightmare_full-barded1"
 #tag "eliteversion equine_nightmare_scale-barded1"
 #tag "minprot 10"
-#chanceinc primaryrace "Human (Amazon)" *5
+#chanceinc primaryrace "Amazon human" *5
 #enditem
 
 #newitem
@@ -112,7 +112,7 @@
 #description "The riders animate their undead horses with their own life force; this is exhausting, but the nightmares cause fear in their enemies."
 #basechance 0.5
 #tag "minprot 12"
-#chanceinc primaryrace "Human (Amazon)" *5
+#chanceinc primaryrace "Amazon human" *5
 #enditem
 
 #newitem
@@ -141,7 +141,7 @@
 #tag "eliteversion equine_nightmare_full-barded1"
 #tag "eliteversion equine_nightmare_full-barded2"
 #tag "minprot 10"
-#chanceinc primaryrace "Human (Amazon)" *5
+#chanceinc primaryrace "Amazon human" *5
 #enditem
 
 
@@ -200,7 +200,7 @@
 #description "The riders animate their undead horses with their own life force; this is exhausting, but the nightmares cause fear in their enemies."
 #basechance 0.25
 #tag "minprot 12"
-#chanceinc primaryrace "Human (Amazon)" *5
+#chanceinc primaryrace "Amazon human" *5
 #enditem
 
 #newitem
@@ -256,7 +256,7 @@
 #description "The riders animate their undead horses with their own life force; this is exhausting, but the nightmares cause fear in their enemies."
 #basechance 0.25
 #tag "minprot 14"
-#chanceinc primaryrace "Human (Amazon)" *5
+#chanceinc primaryrace "Amazon human" *5
 #enditem
 
 #newitem
@@ -283,7 +283,7 @@
 #description "The riders animate their undead lions with their own life force; this is exhausting, but the nightmares cause fear in their enemies."
 #basechance 0.2
 #tag "minprot 10"
-#chanceinc primaryrace "Human (Amazon)" *5
+#chanceinc primaryrace "Amazon human" *5
 #enditem
 
 #newitem
@@ -310,5 +310,5 @@
 #description "The riders animate their undead leogryphs with their own life force; this is exhausting, but the nightmares cause fear in their enemies."
 #basechance 0.2
 #tag "minprot 10"
-#chanceinc primaryrace "Human (Amazon)" *5
+#chanceinc primaryrace "Amazon human" *5
 #enditem

--- a/data/items/amazon/mounted/amazonmounts_low.txt
+++ b/data/items/amazon/mounted/amazonmounts_low.txt
@@ -23,7 +23,7 @@
 #description "The riders animate their undead lizards with their own life force; this is exhausting, but the nightmares cause fear in their enemies."
 #basechance 0.5
 #tag "minprot 10"
-#chanceinc primaryrace "Human (Amazon)" *5
+#chanceinc primaryrace "Amazon human" *5
 #enditem
 
 #newitem
@@ -52,5 +52,5 @@
 #description "The riders animate their undead serpents with their own life force; this is exhausting, but the nightmares cause fear in their enemies. Since the serpent's flesh has not yet rotted away, its bite remains venomous, and it is stable enough for a friendly necromancer to compel to fight on briefly after its rider dies."
 #basechance 0.2
 #tag "minprot 10"
-#chanceinc primaryrace "Human (Amazon)" *5
+#chanceinc primaryrace "Amazon human" *5
 #enditem

--- a/data/items/human/human_mounted/humanmounts.txt
+++ b/data/items/human/human_mounted/humanmounts.txt
@@ -391,7 +391,7 @@
 #offsetx -1
 #tag "animal lion"
 #tag "guaranteedprefix lion"
-#chanceinc primaryrace "human (black)" *10
+#chanceinc primaryrace "Austral human" *10
 #enditem
 
 #newitem

--- a/data/items/human/human_mounted/humanmounts_low.txt
+++ b/data/items/human/human_mounted/humanmounts_low.txt
@@ -128,7 +128,7 @@
 #tag "guaranteedprefix spider"
 #tag "minprot 0"
 #tag "maxprot 12"
-#chanceinc primaryrace "human (black)" *10
+#chanceinc primaryrace "Austral human" *10
 #enditem
 
 #newitem
@@ -156,7 +156,7 @@
 #tag "guaranteedprefix spider"
 #tag "minprot 13"
 #tag "maxprot 100"
-#chanceinc primaryrace "human (black)" *10
+#chanceinc primaryrace "Austral human" *10
 #enditem
 
 
@@ -315,7 +315,7 @@
 #tag "minprot 14"
 #tag "maxprot 20"
 #sacredextra nonholyshape 0.7
-#chanceinc primaryrace "human (black)" *10
+#chanceinc primaryrace "Austral human" *10
 #enditem
 
 

--- a/data/names/magenames/names.txt
+++ b/data/names/magenames/names.txt
@@ -1207,7 +1207,7 @@
 #chanceinc "personalcommand #mounted 0.25"
 #chanceinc "filter warriormage *2"
 #chanceinc "filter thug-tier2 *2"
-#racevariant "Human (Amazon)" "warrior-maiden"
+#racevariant "Amazon human" "warrior-maiden"
 #end
 
 #new
@@ -1217,5 +1217,5 @@
 #chanceinc "filter warriormage 0.1"
 #chanceinc "filter thug-tier2 0.1"
 #chanceinc "personalmagic holy 1 *2"
-#racevariant "Human (Amazon)" "warrior-priestess"
+#racevariant "Amazon human" "warrior-priestess"
 #end

--- a/data/names/magenames/tieredpriestnames.txt
+++ b/data/names/magenames/tieredpriestnames.txt
@@ -239,7 +239,7 @@
 #name "acolyte"
 #rank 1
 #basechance 12
-#racevariant "Human (Amazon)" "sacred maiden"
+#racevariant "Amazon human" "sacred maiden"
 #racevariant "Agarthan" attendant
 #racevariant "Ape" brahmin
 #racevariant "Van" gode
@@ -250,7 +250,7 @@
 #name "acolyte"
 #rank 1
 #basechance 4
-#racevariant "Human (Amazon)" "sacred maiden"
+#racevariant "Amazon human" "sacred maiden"
 #racevariant "Atlantian" consort
 #racevariant "Fomorian" druid
 #racevariant "Lizard" scion
@@ -303,7 +303,7 @@
 #racevariant "Abysian" anathemant
 #racevariant "Agarthan" oracle
 #racevariant "Lizard" king
-#racevariant "Human (black)" king
+#racevariant "Austral human" king
 #racevariant "Ape" guru
 #commandvariant #female "high priestess"
 #end

--- a/data/names/sacredbasenames.txt
+++ b/data/names/sacredbasenames.txt
@@ -60,7 +60,7 @@
 
 #new 
 #name "master"
-#racevariant "Human (Amazon)" maiden
+#racevariant "Amazon human" maiden
 #basechance 1
 #end
 

--- a/data/names/troopnaming/troopmiscitemnames.txt
+++ b/data/names/troopnaming/troopmiscitemnames.txt
@@ -14,7 +14,7 @@
 #new 
 #name "knight"
 #racevariant "Oriental human" samurai
-#racevariant "Human (Amazon)" cataphract
+#racevariant "Amazon human" cataphract
 #basechance 0
 #chanceinc "pose mounted 2"
 #chanceinc "prot below 13 *0"

--- a/data/poses/gaian/minotaurmages.txt
+++ b/data/poses/gaian/minotaurmages.txt
@@ -6,8 +6,6 @@
 #role "mage"
 #role "priest"
 
-#subrace "minotaur"
-
 #load basesprite /data/items/gaian/minotaur/bases_caster.txt
 #load shadow /data/items/gaian/minotaur/shadow.txt
 #load hands /data/items/gaian/minotaur/hafted_hands.txt
@@ -34,8 +32,6 @@
 #name "tier 2-3 mature elder"
 #role "mage"
 #role "priest"
-
-#subrace "minotaur"
 
 #renderorder "shadow weapon cloakb basesprite armor bonusweapon offhandw hands cloakf helmet offhanda"
 

--- a/data/poses/gaian/minotaurtroops.txt
+++ b/data/poses/gaian/minotaurtroops.txt
@@ -9,8 +9,6 @@
 #basedchance 2
 #theme "savage"
 
-#subrace "minotaur"
-
 #command "#trample"
 
 #load basesprite /data/items/gaian/minotaur/bases.txt
@@ -38,8 +36,6 @@
 
 #basedchance 0.5
 #theme "savage"
-
-#subrace "minotaur"
 
 #command "#trample"
 
@@ -70,8 +66,6 @@
 
 #basechance 3
 
-#subrace "minotaur"
-
 #command "#trample"
 
 #load basesprite /data/items/gaian/minotaur/2h_bases.txt
@@ -90,6 +84,7 @@
 
 #endpose
 
+
 -------- Peltasts and other lower-discipline soldiers
 #newpose
 #name "soldiers"
@@ -100,8 +95,6 @@
 
 #basedchance 1
 #theme "civilized"
-
-#subrace "minotaur"
 
 #command "#trample"
 #command "#def +1"
@@ -135,8 +128,6 @@
 
 #basedchance 0.5
 #theme "civilized"
-
-#subrace "minotaur"
 
 #command "#formationfighter +1"
 #command "#mor +1"

--- a/data/races/advancedhumans.txt
+++ b/data/races/advancedhumans.txt
@@ -1,5 +1,5 @@
 #newrace
-#name "Human (advanced)"
+#name "Advanced human"
 #visiblename "Human"
 #basechance 0.25
 

--- a/data/races/amazon.txt
+++ b/data/races/amazon.txt
@@ -1,5 +1,5 @@
 #newrace
-#name "Human (Amazon)"
+#name "Amazon human"
 #visiblename "Human"
 #basechance 0.375
 

--- a/data/races/lizards.txt
+++ b/data/races/lizards.txt
@@ -56,6 +56,6 @@
 #magicpriority water 4
 
 #chanceinc "primaryrace van *0.1"
-#chanceinc primaryrace "human (black)" *3
+#chanceinc primaryrace "Austral human" *3
 
 #endrace

--- a/data/races/machakans.txt
+++ b/data/races/machakans.txt
@@ -1,5 +1,5 @@
 #newrace
-#name "Human (black)"
+#name "Austral human"
 #visiblename "Human"
 #basechance 0.375
 #all_troops_elite

--- a/data/themes/hoburg_themes.txt
+++ b/data/themes/hoburg_themes.txt
@@ -13,7 +13,7 @@
 #basechance 0.5
 #chanceinc era 3 -0.25
 #chanceinc era 1 +1
-#chanceinc primaryrace 'Human (advanced)' *0.25
+#chanceinc primaryrace 'Advanced human' *0.25
 #themeinc theme mechanical *0.05
 #themeinc theme advanced *0.05
 #themeinc theme iron *0.05
@@ -45,7 +45,7 @@
 #name agrarian
 #basechance 1
 #chanceinc era 3 -0.5
-#chanceinc primaryrace 'Human (advanced)' *0.5
+#chanceinc primaryrace 'Advanced human' *0.5
 #themeinc theme mechanical *0.05
 #themeinc theme advanced *0.25
 #themeinc theme iron *1
@@ -72,7 +72,7 @@
 #basechance 0.10
 #chanceinc era 3 1.9
 #chanceinc era 2 0.9
-#chanceinc primaryrace 'Human (advanced)' *4
+#chanceinc primaryrace 'Advanced human' *4
 #themeinc theme mechanical +0.025
 #themeinc theme advanced *2
 #themeinc theme iron *2
@@ -97,7 +97,7 @@
 #basechance 0.025
 #chanceinc era 3 *40
 #chanceinc era 2 *12
-#chanceinc primaryrace 'Human (advanced)' *2
+#chanceinc primaryrace 'Advanced human' *2
 #themeinc theme mechanical +0.1
 #themeinc theme mechanical *2
 #themeinc theme advanced *3
@@ -223,7 +223,7 @@
 #chanceinc racetheme agrarian *3
 #chanceinc racetheme advanced *3
 #chanceinc racetheme industrial *1
-#chanceinc primaryrace 'Human (black)' *5
+#chanceinc primaryrace 'Austral human' *5
 #chanceinc primaryrace Lizard *2.5
 #chanceinc primaryrace Avvite *2.5
 #chanceinc primaryrace van *0.5
@@ -257,7 +257,7 @@
 #chanceinc racetheme agrarian *4
 #chanceinc racetheme advanced *2
 #chanceinc racetheme industrial *0.25
-#chanceinc primaryrace 'Human (Amazon)' *5
+#chanceinc primaryrace 'Amazon human' *5
 #chanceinc primaryrace Minotaur *5
 #chanceinc primaryrace Lizard *2
 #chanceinc primaryrace Avvite *2

--- a/data/themes/van_themes.txt
+++ b/data/themes/van_themes.txt
@@ -62,7 +62,7 @@
 #themeinc racename ape *0.1
 #themeinc racename avvite *0.1
 #themeinc racename abysian *0.1
-#themeinc racename "Human (black)" *0.1
+#themeinc racename "Austral human" *0.1
 #themeinc racename zotz *0.1
 #themeinc racename muuch *0.1
 #themeinc racename tengu *0.1

--- a/documentation/special_commands.txt
+++ b/documentation/special_commands.txt
@@ -211,7 +211,7 @@ Increases the cost of the mage with this pattern by given price.
 
 -- Names
 #racevariant <internal race name> <name>
-Uses this name instead for given race. Use internal race names, ie "Human (black)" for Machakans and so on.
+Uses this name instead for given race. Use internal race names, ie "Austral human" for Machakans and so on.
 
 #posetagvariant <tag> <name> 
 #racetagvariant <tag> <name>

--- a/graphics/monsters/supermonsters.txt
+++ b/graphics/monsters/supermonsters.txt
@@ -26,7 +26,7 @@
 #new
 #name "elephant_human_4"
 #basechance 0
-#chanceinc race "human (black)" 1
+#chanceinc race "Austral human" 1
 #command "#copystats 2307"
 #command "#copyspr 2307"
 #end


### PR DESCRIPTION
Human -> [no change]
Oriental human -> [model; no change]
Human (black) -> Austral human
Human (advanced) -> Advanced human
Human (Amazon) -> Amazon human

This is a cosmetic change mostly made to make the names that just
started being displayed in Adv. Desc. files look a bit more homogenous
and less clunky than the e.g. "(Human (Amazon))" or "(Human (black) -
colossi)" that the current names result in. Also, eliminated Minotaur as
an internal subrace to expunge "(Minotaur - minotaur)" labels; depending
on how the rest of the "Gaian" races are implemented (demographic themes
vs. distinct allied races), it may come back later or stay gone.