### PR TITLE
Shambler cost adjustment

### DIFF
--- a/data/items/atlantian/shamblerbases.txt
+++ b/data/items/atlantian/shamblerbases.txt
@@ -2,7 +2,7 @@
 #name "shambler basesprite"
 #gameid -1
 #sprite /graphics/atlantian/baseshambler.png
-#define "#gcost +18"
+#define "#gcost +8"
 #define "#hp +10"
 #define "#mor +1"
 #define "#str +4"

--- a/data/items/muuch/shamblerbases.txt
+++ b/data/items/muuch/shamblerbases.txt
@@ -3,7 +3,7 @@
 #gameid -1
 #sprite /graphics/muuch/basesprite_darkgreen_medium.png
 #needs hands darkgreen
-#define "#gcost +18"
+#define "#gcost +8"
 #define "#hp +12"
 #define "#mor +1"
 #define "#str +4"


### PR DESCRIPTION
In keeping with 4.20, shambler base cost has been reduced to 20g - from
the 30g (!) it currently is, which seems to be based on war shambler
prices even though they have normal shambler stats.