### PR TITLE
Example for debugging the elites issue

### DIFF
--- a/data/poses/caelian/troops.txt
+++ b/data/poses/caelian/troops.txt
@@ -3,8 +3,8 @@
 
 #newpose
 #role "infantry"
-#role "sacred infantry"
-#role "elite infantry"
+-- #role "sacred infantry"
+-- #role "elite infantry"
 #role "scout"
 
 #renderorder "shadow cloakb wings basesprite mount shirt legs armor cloakf quiver bonusweapon weapon offhandw hands hair helmet offhanda overlay"
@@ -41,8 +41,8 @@
 
 #newpose
 #role "ranged"
-#role "sacred ranged"
-#role "elite ranged"
+-- #role "sacred ranged"
+-- #role "elite ranged"
 
 #renderorder "shadow cloakb wings basesprite mount shirt legs armor cloakf quiver bonusweapon weapon offhandw hands hair helmet offhanda overlay"
 
@@ -76,8 +76,8 @@
 #newpose
 #theme advanced
 #role "ranged"
-#role "sacred ranged"
-#role "elite ranged"
+-- #role "sacred ranged"
+-- #role "elite ranged"
 #basechance 0.33
 
 #renderorder "shadow cloakb wings basesprite mount shirt legs armor cloakf quiver bonusweapon weapon offhandw hands hair helmet offhanda overlay"


### PR DESCRIPTION
Nation seed 145208006 will cause the error.

For 3+ nations, mod seed  -878385423 will result in two good nations
with the race tags "all_troops_sacred" and "all_troops_elite" present,
and the third (145208006) will have neither tag in the race's tag list.