### PR TITLE
determineSpecialLeadership wasn't catching all special types

### DIFF
--- a/src/nationGen/magic/MageGenerator.java
+++ b/src/nationGen/magic/MageGenerator.java
@@ -1311,7 +1311,7 @@ public class MageGenerator extends TroopGenerator {
 		return priests;
 	}
 	
-	private void determineSpecialLeadership(Unit u)
+	public static void determineSpecialLeadership(Unit u)
 	{
 		String basiclevel = u.getLeaderLevel();
 		

--- a/src/nationGen/units/Unit.java
+++ b/src/nationGen/units/Unit.java
@@ -24,9 +24,11 @@ import javax.imageio.ImageIO;
 
 
 
+
 import com.elmokki.Dom3DB;
 import com.elmokki.Drawing;
 import com.elmokki.Generic;
+
 
 
 
@@ -47,6 +49,7 @@ import nationGen.entities.MagicFilter;
 import nationGen.entities.Pose;
 import nationGen.entities.Race;
 import nationGen.items.Item;
+import nationGen.magic.MageGenerator;
 import nationGen.misc.ChanceIncHandler;
 import nationGen.misc.Command;
 import nationGen.naming.Name;
@@ -411,7 +414,7 @@ public class Unit {
 		for(Command c : this.getCommands())
 		{
 			String lead = null;
-			if(c.command.endsWith("leader"))
+			if(c.command.endsWith(prefix + "leader"))
 				lead = c.command.substring(1, c.command.indexOf(prefix + "leader"));
 			
 			if(levels.contains(lead))
@@ -986,8 +989,16 @@ public class Unit {
 			}
 		}
 		
+		boolean isMage = false;
 		
+		for(Command c : commands)
+		{
+			if(c.command.equals("#magicskill") || c.command.equals("#custommagic"))
+				isMage = true;
+		}
 		
+		if(isMage) 
+			MageGenerator.determineSpecialLeadership(u);
 		
 		polished = true;
 	}


### PR DESCRIPTION
* magic/demon/undead units who were e.g. getting their status from an item (like basesprite) were not being properly processed because commands[] hadn't had the command added at the point where dSL() was invoked. A call to dSL() was added for all casters at the end of polish(), although that may well not be a good place to add it - also, it looks like non-caster heroes aren't getting special leadership added, so it might be better if this was done for all non-scout leaders instead of just casters.