### PR TITLE
changed the second, smaller, cav chance for lizards to sacred cav chance

### DIFF
--- a/data/races/lizards.txt
+++ b/data/races/lizards.txt
@@ -43,7 +43,7 @@
 #generationchance cavalry 0.125
 
 #sacredchariotchance 0.25
-#generationchance cavalry 0.05
+#sacredcavalrychance cavalry 0.05
 
 #magicpatterns defaultprimary
 #magicpatterns defaultsecondary


### PR DESCRIPTION
It is next to sacred chariots, so I'm pretty sure that's what it's supposed to be.