### PR TITLE
PD commander fix

### DIFF
--- a/src/nationGen/nation/PDSelector.java
+++ b/src/nationGen/nation/PDSelector.java
@@ -49,9 +49,9 @@ public class PDSelector {
 		{
 			double rand = r.nextDouble();
 			if(rand < 0.025)
-				commanders.add(0, n.generateComList("priest").get(0));
+				commanders.add(rank - 1, n.generateComList("priest").get(0));
 			else if(rand < 0.1)
-				commanders.add(1, n.generateComList("priest").get(0));
+				commanders.add(rank, n.generateComList("priest").get(0));
 		}
 		
 		List<Unit> others = new ArrayList<Unit>();
@@ -141,7 +141,7 @@ public class PDSelector {
 				com.commands.add(new Command("#undcommand", "40"));
 		}
 		
-		return commanders.get(0);
+		return com;
 	}
 	
 	/**


### PR DESCRIPTION
PD commander selection was just pulling the first commander off its list every time instead of using the list of valid commanders it generated.

Priest selection was concurrently adjusted because otherwise fixing this meant double PD commanders would result any time a priest was placed at the start of the commander list.

Closes #359