### PR TITLE
Bronze lance fix

### DIFF
--- a/data/items/customitems.txt
+++ b/data/items/customitems.txt
@@ -258,6 +258,7 @@
 #command "#bonus"
 #command "#charge"
 #command "#pierce"
+#command "#ammo 1"
 #command "#name 'Heavy Bronze Lance'"
 #end
 


### PR DESCRIPTION
#singleuse does not work. Added #ammo 1 which should work, but I did not bother testing.