### PR TITLE
More 4.25 pricing updates

### DIFF
--- a/data/items/agarthan/generic_big/bases.txt
+++ b/data/items/agarthan/generic_big/bases.txt
@@ -2,7 +2,7 @@
 #name "agarthan basesprite"
 #gameid -1
 #sprite /graphics/agarthan/big/basesprite.png
-#define "#gcost +25"
+#define "#gcost +21"
 #define "#size 4"
 #define "#enc 4"
 #define "#mr 14"

--- a/data/items/agarthan/generic_big/rangedbases.txt
+++ b/data/items/agarthan/generic_big/rangedbases.txt
@@ -3,7 +3,7 @@
 #gameid -1
 #sprite /graphics/agarthan/big/basesprite.png
 #needs strap strap
-#define "#gcost +25"
+#define "#gcost +21"
 #define "#size 4"
 #define "#enc 4"
 #define "#mr 14"

--- a/data/items/monkey/vanara/caster/magebases.txt
+++ b/data/items/monkey/vanara/caster/magebases.txt
@@ -3,7 +3,7 @@
 #gameid -1
 #sprite /graphics/monkey/vanara_base_old.png
 #needs hands vanara_hands
-#command "#gcost 10"
+#command "#gcost 9"
 #command "#hp 10"
 #command "#mr 8"
 #command "#prot 1"
@@ -21,7 +21,7 @@
 #sprite /graphics/monkey/vanara_base_old.png
 #needs hands vanara_hands
 #needs wings winged
-#command "#gcost 15"
+#command "#gcost 14"
 #command "#hp 10"
 #command "#mr 10"
 #command "#prot 1"
@@ -43,7 +43,7 @@
 #gameid -1
 #sprite /graphics/monkey/vanara_base_vanarabred.png
 #needs hands vanarabred_hands
-#command "#gcost 12"
+#command "#gcost 11"
 #command "#hp 12"
 #command "#mr 9"
 #command "#prot 1"
@@ -64,7 +64,7 @@
 #gameid -1
 #sprite /graphics/monkey/vanara_base_alpine_old.png
 #needs hands vanara_hands_alpine
-#command "#gcost 11"
+#command "#gcost 10"
 #command "#hp 10"
 #command "#mr 9"
 #command "#prot 2"

--- a/data/items/monkey/vanara/caster/magebases_float.txt
+++ b/data/items/monkey/vanara/caster/magebases_float.txt
@@ -2,7 +2,7 @@
 #name "vanara basesprite floating"
 #gameid -1
 #sprite /graphics/monkey/vanara_base_old_floating.png
-#command "#gcost 10"
+#command "#gcost 9"
 #command "#hp 10"
 #command "#mr 10"
 #command "#animal"

--- a/data/items/monkey/vanara/caster/magebases_sit.txt
+++ b/data/items/monkey/vanara/caster/magebases_sit.txt
@@ -2,7 +2,7 @@
 #name "vanara basesprite"
 #gameid -1
 #sprite /graphics/monkey/vanara_base_old_sitting.png
-#command "#gcost 10"
+#command "#gcost 9"
 #command "#hp 10"
 #command "#mr 8"
 #command "#animal"

--- a/data/items/monkey/vanara/mounted/bases.txt
+++ b/data/items/monkey/vanara/mounted/bases.txt
@@ -3,7 +3,7 @@
 #gameid -1
 #sprite /graphics/monkey/vanara_base_mounted.png
 #needs hands vanara_hands
-#command "#gcost 10"
+#command "#gcost 9"
 #command "#hp 10"
 #command "#mr 8"
 #command "#prot 1"
@@ -21,7 +21,7 @@
 #sprite /graphics/monkey/vanara_base.png
 #needs hands vanara_hands
 #needs wings winged
-#command "#gcost 15"
+#command "#gcost 14"
 #command "#hp 10"
 #command "#mr 10"
 #command "#prot 1"
@@ -39,7 +39,7 @@
 #gameid -1
 #sprite /graphics/monkey/vanara_base_vanarabred_mounted.png
 #needs hands vanarabred_hands
-#command "#gcost 12"
+#command "#gcost 11"
 #command "#hp 12"
 #command "#mr 9"
 #command "#prot 1"
@@ -60,7 +60,7 @@
 #gameid -1
 #sprite /graphics/monkey/vanara_base_alpine_mounted.png
 #needs hands vanara_hands_alpine
-#command "#gcost 11"
+#command "#gcost 10"
 #command "#hp 10"
 #command "#mr 9"
 #command "#prot 2"

--- a/data/items/monkey/vanara/mounted/sacredbases.txt
+++ b/data/items/monkey/vanara/mounted/sacredbases.txt
@@ -3,7 +3,7 @@
 #gameid -1
 #sprite /graphics/monkey/vanara_base_white_mounted.png
 #needs hands vanara_hands
-#command "#gcost 10"
+#command "#gcost 9"
 #command "#hp 10"
 #command "#mr 8"
 #command "#prot 1"
@@ -21,7 +21,7 @@
 #sprite /graphics/monkey/vanara_base_white.png
 #needs hands vanara_hands
 #needs wings winged
-#command "#gcost 15"
+#command "#gcost 14"
 #command "#hp 10"
 #command "#mr 10"
 #command "#prot 1"
@@ -39,7 +39,7 @@
 #gameid -1
 #sprite /graphics/monkey/vanara_base_vanarabred_mounted.png
 #needs hands vanarabred_hands
-#command "#gcost 12"
+#command "#gcost 11"
 #command "#hp 12"
 #command "#mr 9"
 #command "#prot 1"
@@ -60,7 +60,7 @@
 #gameid -1
 #sprite /graphics/monkey/vanara_base_alpine_mounted.png
 #needs hands vanara_hands_alpine
-#command "#gcost 11"
+#command "#gcost 10"
 #command "#hp 10"
 #command "#mr 9"
 #command "#prot 2"

--- a/data/items/monkey/vanara/normal/bases.txt
+++ b/data/items/monkey/vanara/normal/bases.txt
@@ -3,7 +3,7 @@
 #gameid -1
 #sprite /graphics/monkey/vanara_base.png
 #needs hands vanara_hands
-#command "#gcost 10"
+#command "#gcost 9"
 #command "#hp 10"
 #command "#mr 8"
 #command "#prot 1"
@@ -21,7 +21,7 @@
 #sprite /graphics/monkey/vanara_base.png
 #needs hands vanara_hands
 #needs wings winged
-#command "#gcost 15"
+#command "#gcost 14"
 #command "#hp 10"
 #command "#mr 10"
 #command "#prot 1"
@@ -43,7 +43,7 @@
 #gameid -1
 #sprite /graphics/monkey/vanara_base_vanarabred.png
 #needs hands vanarabred_hands
-#command "#gcost 12"
+#command "#gcost 11"
 #command "#hp 12"
 #command "#mr 9"
 #command "#prot 1"
@@ -64,7 +64,7 @@
 #gameid -1
 #sprite /graphics/monkey/vanara_base_alpine.png
 #needs hands vanara_hands_alpine
-#command "#gcost 11"
+#command "#gcost 10"
 #command "#hp 10"
 #command "#mr 9"
 #command "#prot 2"

--- a/data/items/monkey/vanara/normal/sacredbases.txt
+++ b/data/items/monkey/vanara/normal/sacredbases.txt
@@ -3,7 +3,7 @@
 #gameid -1
 #sprite /graphics/monkey/vanara_base_white.png
 #needs hands vanara_hands
-#command "#gcost 10"
+#command "#gcost 9"
 #command "#hp 10"
 #command "#mr 8"
 #command "#prot 1"
@@ -21,7 +21,7 @@
 #sprite /graphics/monkey/vanara_base_white.png
 #needs hands vanara_hands
 #needs wings winged
-#command "#gcost 15"
+#command "#gcost 14"
 #command "#hp 10"
 #command "#mr 10"
 #command "#prot 1"
@@ -43,7 +43,7 @@
 #gameid -1
 #sprite /graphics/monkey/vanara_base_vanarabred.png
 #needs hands vanarabred_hands
-#command "#gcost 12"
+#command "#gcost 11"
 #command "#hp 12"
 #command "#mr 9"
 #command "#prot 1"
@@ -63,7 +63,7 @@
 #gameid -1
 #sprite /graphics/monkey/vanara_base_alpine.png
 #needs hands vanara_hands_alpine
-#command "#gcost 11"
+#command "#gcost 10"
 #command "#hp 10"
 #command "#mr 9"
 #command "#prot 2"

--- a/data/poses/agarthan/agarthanmages.txt
+++ b/data/poses/agarthan/agarthanmages.txt
@@ -65,7 +65,7 @@
 #subrace "olmspawn"
 
 #command "#prot +2"
-#command "#gcost +20"
+#command "#gcost +16"
 #command "#hp +6"
 #command "#att +1"
 #command "#def +1"
@@ -107,7 +107,7 @@
 #subrace "olmspawn"
 
 #command "#prot +2"
-#command "#gcost +20"
+#command "#gcost +16"
 #command "#hp +6"
 #command "#att +1"
 #command "#def +1"

--- a/data/poses/agarthan/agarthantroops.txt
+++ b/data/poses/agarthan/agarthantroops.txt
@@ -194,7 +194,7 @@
 #subrace "olmspawn"
 
 #command "#prot +2"
-#command "#gcost +20"
+#command "#gcost +16"
 #command "#hp +6"
 #command "#att +1"
 #command "#def +1"
@@ -237,7 +237,7 @@
 #subrace "olmspawn"
 
 #command "#prot +2"
-#command "#gcost +20"
+#command "#gcost +16"
 #command "#hp +6"
 #command "#att +1"
 #command "#def +1"
@@ -336,7 +336,7 @@
 #subrace "olmspawn"
 
 #command "#prot +2"
-#command "#gcost +20"
+#command "#gcost +16"
 #command "#hp +6"
 #command "#att +1"
 #command "#def +1"


### PR DESCRIPTION
* Reduced all vanara basecosts by 1g (10/15/12/11g->9/14/11/10g for lowland/winged/vanarabred/alpine)
* Reduced olmspawn basecosts from 30g->25g (in-game sacred unit is 45g->35g)
* Reduced ancient pale one basecosts from 35g->30g (in-game sacred units are 50g->40g)