### PR TITLE
Fixed bug with highestcaponlychance

### DIFF
--- a/src/nationGen/rostergeneration/SacredGenerator.java
+++ b/src/nationGen/rostergeneration/SacredGenerator.java
@@ -631,13 +631,13 @@ public class SacredGenerator extends TroopGenerator {
 		u.commands.add(new Command("#gcost", "*" + total));
 
 		
-		// The highest caponlychyance for the unit will apply if one is defined, unless the default formula is higher 
+		// The highest caponlychance for the unit will apply if one is defined, unless the default formula is higher 
 		values = Generic.getTagValues(Generic.getAllUnitTags(u), "caponlychance");
 		double highestcaponlychance = 0;
 		for(String str : values)
 		{
-			if(highestcaponlychance < Double.parseDouble(str.substring(1)))
-				highestcaponlychance = Double.parseDouble(str.substring(1));
+			if(highestcaponlychance < Double.parseDouble(str))
+				highestcaponlychance = Double.parseDouble(str);
 		}
 		
 		if(highestcaponlychance < ((power + rating) / 10 + 0.3))


### PR DESCRIPTION
I'm fairly certain this was a bug and not a data error, anyway: #caponlychance is currently used in the data files as a double from 0 - 1, and SacredGenerator was trying to read the arguments to #caponlychance by doing a cdr of the argument, so if the caponlychance was 1 (or 0) it would have an array index out of bounds exception.