### PR TITLE
Survivals for scouts

### DIFF
--- a/src/nationGen/rostergeneration/ScoutGenerator.java
+++ b/src/nationGen/rostergeneration/ScoutGenerator.java
@@ -224,6 +224,97 @@ public class ScoutGenerator extends TroopGenerator {
 		
 		}
 	
+		// Crude block to survival skills
+		boolean mounted = false;
+		boolean flying = false;
+		boolean amphibian = false;
+		boolean aquatic = false;
+		boolean mountain = false;
+		boolean forest = false;
+		boolean waste = false;
+		boolean swamp = false;
+		int survivals = 0;
+		for(Command c : template.getCommands())
+		{
+			if(c.command.equals("#mounted"))
+				mounted = true;
+			if(c.command.equals("#flying"))
+				flying = true;
+			if(c.command.equals("#amphibian"))
+				amphibian = true;
+			if(c.command.equals("#aquatic"))
+				aquatic = true;
+			if(c.command.equals("#mountainsurvival") && !mountain)
+			{
+				mountain = true;
+				survivals++;
+			}
+			if(c.command.equals("#forestsurvival") && !forest)
+			{
+				forest = true;
+				survivals++;
+			}
+			if(c.command.equals("#wastesurvival") && !waste)
+			{
+				waste = true;
+				survivals++;
+			}
+			if(c.command.equals("#swampsurvival") && !swamp)
+			{
+				swamp = true;
+				survivals++;
+			}
+		}
+		
+		// If we are a scout with no special movement type and no more than 2 survivals, ensure they end up with 2-3 survivals
+		if(!flying &&
+				!mounted &&
+				!aquatic &&
+				!amphibian &&
+				tier == 1 &&
+				survivals <= 2)
+		{
+
+			if(survivals == 0)
+			{
+				template.commands.add(new Command("#mountainsurvival"));
+				mountain = true;
+				template.commands.add(new Command("#forestsurvival"));
+				forest = true;
+			}
+			
+			if(survivals == 1)
+			{
+				if(mountain || swamp)
+				{
+					template.commands.add(new Command("#forestsurvival"));
+					forest = true;
+				}
+				else if(forest || waste)
+				{
+					template.commands.add(new Command("#mountainsurvival"));
+					mountain = true;
+				}
+			}
+			
+			double bonuschance = r.nextDouble();
+			if(mountain && forest)
+			{
+				if(bonuschance < 0.2)
+					template.commands.add(new Command("#wastesurvival"));
+				else if(bonuschance < 0.25)
+					template.commands.add(new Command("#swampsurvival"));					
+			}
+			else if(!mountain && bonuschance < 0.25)
+			{
+				template.commands.add(new Command("#mountainsurvival"));				
+			}
+			else if(!forest && bonuschance < 0.25)
+			{
+				template.commands.add(new Command("#forestsurvival"));				
+			}
+
+		}
 		
 		template.color = new Color(60, 60, 60);
 		


### PR DESCRIPTION
* Ugly implementation of scout survivals in scoutgenerator; scouts (and only scouts) who do not have flying, mounted, amphibian, aquatic, or 3+ survivals from their race/pose/items/etc. will have enough survivals added to give them at least 2 and a 25% chance of 3, with priority given in order of mountain (because this increases mobility)>forest>waste (because mountain/forest/swamp is the most common trio)>swamp, with the exception that scouts with native swamp survival (and no other survival) will favor forest first and mountain second.
* Closes #513 