### PR TITLE
Revert Olmspawn changes, tweak Ancient costs

### DIFF
--- a/data/items/agarthan/generic_big/bases.txt
+++ b/data/items/agarthan/generic_big/bases.txt
@@ -2,7 +2,7 @@
 #name "agarthan basesprite"
 #gameid -1
 #sprite /graphics/agarthan/big/basesprite.png
-#define "#gcost +21"
+#define "#gcost +24"
 #define "#size 4"
 #define "#enc 4"
 #define "#mr 14"

--- a/data/items/agarthan/generic_big/rangedbases.txt
+++ b/data/items/agarthan/generic_big/rangedbases.txt
@@ -3,7 +3,7 @@
 #gameid -1
 #sprite /graphics/agarthan/big/basesprite.png
 #needs strap strap
-#define "#gcost +21"
+#define "#gcost +24"
 #define "#size 4"
 #define "#enc 4"
 #define "#mr 14"

--- a/data/poses/agarthan/agarthanmages.txt
+++ b/data/poses/agarthan/agarthanmages.txt
@@ -65,7 +65,7 @@
 #subrace "olmspawn"
 
 #command "#prot +2"
-#command "#gcost +16"
+#command "#gcost +24"
 #command "#hp +6"
 #command "#att +1"
 #command "#def +1"
@@ -107,7 +107,7 @@
 #subrace "olmspawn"
 
 #command "#prot +2"
-#command "#gcost +16"
+#command "#gcost +24"
 #command "#hp +6"
 #command "#att +1"
 #command "#def +1"

--- a/data/poses/agarthan/agarthantroops.txt
+++ b/data/poses/agarthan/agarthantroops.txt
@@ -194,7 +194,7 @@
 #subrace "olmspawn"
 
 #command "#prot +2"
-#command "#gcost +16"
+#command "#gcost +24"
 #command "#hp +6"
 #command "#att +1"
 #command "#def +1"
@@ -237,7 +237,7 @@
 #subrace "olmspawn"
 
 #command "#prot +2"
-#command "#gcost +16"
+#command "#gcost +24"
 #command "#hp +6"
 #command "#att +1"
 #command "#def +1"
@@ -336,7 +336,7 @@
 #subrace "olmspawn"
 
 #command "#prot +2"
-#command "#gcost +16"
+#command "#gcost +24"
 #command "#hp +6"
 #command "#att +1"
 #command "#def +1"


### PR DESCRIPTION
* Per KO, their price reduction was inadvertant, so now they cost the same amount as Ancient Ones. The basecost in-game for those is 33g, so I bumped their prices up from 30g to 33g as well