### PR TITLE
Priest cost bug

### DIFF
--- a/src/nationGen/magic/MageGenerator.java
+++ b/src/nationGen/magic/MageGenerator.java
@@ -1261,7 +1261,7 @@ public class MageGenerator extends TroopGenerator {
 				u.color = priestcolor;
 				u.appliedFilters.add(this.getPriestPattern(currentStrength));
 				u.commands.add(new Command("#holy"));
-				u.commands.add(new Command("#gcost", "+" + (int)(Math.pow(2, currentStrength)*10) + currentStrength * priestextracost));
+				u.commands.add(new Command("#gcost", "+" + ((int)(Math.pow(2, currentStrength))*10 + currentStrength * priestextracost)));
 				u.tags.add("priest " + currentStrength);
 
 				


### PR DESCRIPTION
* Misplaced paren turned int addition into string concatenation, with the end result of making priests get e.g. #gcost +200 rather than #gcost +20 ("#gcost +" + (int)(20) + (int)(0) rather than "#gcost +" + (int)(20 + 0)...)