### PR TITLE
More missiles for generic-human-set scout bonus weapons

### DIFF
--- a/data/items/human/scout/bonusranged_scout.txt
+++ b/data/items/human/scout/bonusranged_scout.txt
@@ -1,0 +1,180 @@
+#newitem
+#name "javelin 1"
+#gameid 21
+#sprite /graphics/weapon/standard/javelin1.png
+#basechance 0.5
+#theme "occidental"
+#theme "boreal"
+#theme "austral"
+#theme "oriental"
+#theme "central"
+#theme "imperial"
+#enditem
+
+#newitem
+#name "javelin 2"
+#gameid 21
+#basechance 0.5
+#sprite /graphics/weapon/standard/javelin2.png
+#theme "occidental"
+#theme "boreal"
+#theme "austral"
+#theme "oriental"
+#theme "central"
+#theme "imperial"
+#enditem
+
+#newitem
+#name "bonus crossbow"
+#gameid 25
+#sprite /graphics/weapon/standard/bonuscrossbow.png
+#basechance 0.5
+#theme "advanced"
+#theme "iron"
+#theme "boreal"
+#theme "oriental"
+#theme "central"
+#theme "imperial"
+#enditem
+
+#newitem -- Throwing axe
+#name "throwing axe"
+#gameid 260
+#theme "primitive"
+#theme "iron"
+#theme "boreal"
+#theme "central"
+#theme "enlightened"
+#enditem
+
+#newitem
+#name "bonus shortbow"
+#gameid 23
+#sprite /graphics/weapon/standard/bonusshortbow.png
+#basechance 0.5
+#theme "wood"
+#theme "occidental"
+#theme "boreal"
+#theme "austral"
+#theme "oriental"
+#theme "central"
+#theme "imperial"
+#theme "enlightened"
+#enditem
+
+#newitem
+#name "poison shortbow"
+#gameid 594
+#sprite /graphics/weapon/standard/bonusshortbow.png
+#basechance 0.5
+#theme "wood"
+#theme "poison"
+#theme "occidental"
+#theme "austral"
+#theme "oriental"
+#theme "central"
+#theme "enlightened"
+#enditem
+
+#newitem
+#name "bonus sling"
+#gameid 594
+#sprite /graphics/weapon/standard/bonusshortbow.png
+#basechance 0.5
+#theme "leather"
+#theme "occidental"
+#theme "boreal"
+#theme "central"
+#theme "imperial"
+#enditem
+
+#newitem
+#name "poison sling"
+#gameid 167
+#sprite /graphics/weapon/standard/bonusshortbow.png
+#basechance 0.5
+#theme "leather"
+#theme "poison"
+#theme "occidental"
+#theme "central"
+#enditem
+
+#newitem
+#name "chakram"
+#gameid 362
+#sprite /graphics/weapon/standard/chakram.png
+#renderprio 7
+#renderslot "weapon"
+#basechance 0.25
+#theme "iron"
+#theme "central"
+#theme "oriental"
+#theme "enlightened"
+#enditem
+
+#newitem
+#name "sticksandstones"
+#gameid 360
+#basechance 0.25
+#tag "notepic"
+#theme "primitive"
+#theme "occidental"
+#theme "austral"
+#theme "enlightened"
+#enditem
+
+#newitem
+#name "harpoon"
+#gameid 452
+#sprite /graphics/weapon/standard/javelin1.png
+#theme "occidental"
+#theme "boreal"
+#theme "oriental"
+#enditem
+
+#newitem
+#name "blowpipe"
+#gameid 34
+#tag "tierunique"
+#basechance 0.5
+#theme "poison"
+#theme "occidental"
+#theme "austral"
+#theme "oriental"
+#enditem
+
+#newitem
+#name "net"
+#gameid 263
+#sprite /graphics/weapon/standard/net.png
+#tag "noslot offhand"
+#tag "notepic"
+#basechance 0.5
+#theme "occidental"
+#theme "boreal"
+#theme "austral"
+#theme "central"
+#theme "imperial"
+#theme "enlightened"
+#enditem
+
+#newitem
+#name "poison dart"
+#gameid 620
+#basechance 0.5
+#theme "primitive"
+#theme "poison"
+#theme "occidental"
+#theme "austral"
+#theme "oriental"
+#theme "enlightened"
+#enditem
+
+#newitem
+#name "shuriken"
+#gameid 382
+#basechance 0.5
+#theme "poison"
+#theme "oriental"
+#theme "enlightened"
+#enditem

--- a/data/items/illithid/hybrid/armor.txt
+++ b/data/items/illithid/hybrid/armor.txt
@@ -13,7 +13,7 @@
 
 #newitem
 #name "sharkskin cuirass"
-#gameid 5
+#gameid 188
 #sprite /graphics/foulspawn/small/armor/sharkskin_cuirass.png
 #armor
 #theme "leather"
@@ -23,7 +23,7 @@
 
 #newitem
 #name "sharkskin armor"
-#gameid 15
+#gameid 151
 #sprite /graphics/foulspawn/small/armor/sharkskin_full.png
 #armor
 #theme "leather"

--- a/data/poses/amazon/amazoninfantry.txt
+++ b/data/poses/amazon/amazoninfantry.txt
@@ -154,7 +154,7 @@
 #load legs /data/items/amazon/normal/amazonlegs.txt
 
 #load weapon /data/items/human/normal/humanweapon.txt
-#load bonusweapon /data/items/human/normal/humanbonusranged.txt
+#load bonusweapon /data/items/human/scout/bonusranged_scout.txt
 
 #load offhand /data/items/human/normal/humanoffhand.txt offsetx -1 offsety 0
 

--- a/data/poses/human/humaninfantry.txt
+++ b/data/poses/human/humaninfantry.txt
@@ -95,7 +95,7 @@
 #load legs /data/items/human/normal/humanlegs.txt
 
 #load weapon /data/items/human/normal/humanweapon.txt
-#load bonusweapon /data/items/human/normal/humanbonusranged.txt
+#load bonusweapon /data/items/human/scout/bonusranged_scout.txt
 
 #load offhand /data/items/human/normal/humanoffhand.txt
 


### PR DESCRIPTION
* These are all themed by region, so I probably should make distinct scout poses for regional humans who don't have them so they can use these. Plus, obviously, add a bit more weight to the regional themes so e.g. oriental humans are more likely to have shuriken and less likely to have throwing axes.
* Random fix for a illi hybrid armor id error