### PR TITLE
Priest level distribution tweaks

### DIFF
--- a/data/themes/default_nationthemes.txt
+++ b/data/themes/default_nationthemes.txt
@@ -133,7 +133,8 @@
 #command "#sacrificedom"
 #magicpriority blood 10000
 #magepriestchance 1
-#highestpriestlevel 3
+#priest_H1_upgradechance 1
+#priest_H2_upgradechance 0.9
 #desc "Priests are unable to preach but may perform blood sacrifices"
 #end
 
@@ -145,7 +146,8 @@
 #command "#sacrificedom"
 #primaryracedefinition "#magicpriority blood 4"
 #magepriestchance 0.6
-#higherpriestlevelchance 0.6
+#priest_H1_upgradechance 0.8
+#priest_H2_upgradechance 0.3
 #magicpriority blood 2
 #desc "Priests may perform blood sacrifices"
 #end
@@ -195,7 +197,6 @@
 #magicpriority death 256
 #magicpriority nature 256
 #desc "Priests can incite the nature to reanimate dead bodies to fight again. This causes some unrest amongst the population."
-#higherpriestlevelchance 0.75
 #magepriestchance 0.85
 #priestextracost 30
 #end
@@ -573,7 +574,7 @@
 #command "#guardspirit 396"
 #chanceinc primaryrace "Boreal human" 0.0125
 #chanceinc primaryrace "Advanced human" 0.0125
-#higherpriestlevelchance 0.75
+#priest_H1_upgradechance 1
 #desc "Nuns occasionally follow priests in battles"
 #end
 

--- a/src/nationGen/magic/MageGenerator.java
+++ b/src/nationGen/magic/MageGenerator.java
@@ -1098,24 +1098,37 @@ public class MageGenerator extends TroopGenerator {
 		Random r = this.random;
 		
 		
-		double priestUpChance = 0.4;
-		if(Generic.containsTag(Generic.getAllNationTags(nation), "higherpriestlevelchance"))
+		double priest_H1_UpChance = 0.75;
+		if(Generic.containsTag(Generic.getAllNationTags(nation), "priest_H1_upgradechance"))
 		{
-			List<String> possiblevalues = Generic.getTagValues(Generic.getAllNationTags(nation), "higherpriestlevelchance");
+			List<String> possiblevalues = Generic.getTagValues(Generic.getAllNationTags(nation), "priest_H1_upgradechance");
 			double highest = 0;
 			for(String str : possiblevalues)
 			{
 				if(Double.parseDouble(str) > highest)
 					highest = Double.parseDouble(str);
 			}
-			priestUpChance = highest;
+			priest_H1_UpChance = highest;
+		}
+		
+		double priest_H2_UpChance = 0.25;
+		if(Generic.containsTag(Generic.getAllNationTags(nation), "priest_H2_upgradechance"))
+		{
+			List<String> possiblevalues = Generic.getTagValues(Generic.getAllNationTags(nation), "priest_H2_upgradechance");
+			double highest = 0;
+			for(String str : possiblevalues)
+			{
+				if(Double.parseDouble(str) > highest)
+					highest = Double.parseDouble(str);
+			}
+			priest_H2_UpChance = highest;
 		}
 		
 		int maxStrength = 1;
-		if(r.nextDouble() < priestUpChance)
+		if(r.nextDouble() < priest_H1_UpChance)
 		{
 			maxStrength++;
-			if(r.nextDouble() < priestUpChance)
+			if(r.nextDouble() < priest_H2_UpChance)
 				maxStrength++;
 		}
 		
@@ -1214,9 +1227,12 @@ public class MageGenerator extends TroopGenerator {
 		boolean doneWithMages = false;
 		
 		int priestsFrom = 0;
-		if(magePriests && maxStrength > 1 && r.nextDouble() < 0.25)
+		if(magePriests && maxStrength > 1 && r.nextDouble() < 0.75)
 		{
-			priestsFrom = r.nextInt(maxStrength + 1);
+			if(r.nextDouble() < 0.25)
+				priestsFrom = r.nextInt(maxStrength + 1);
+			else
+				priestsFrom = Math.min(2, maxStrength);
 		}
 		
 		int priestextracost = 0;


### PR DESCRIPTION
Old system was very biased towards H1. Now it's biased more towards H2.

Also a slight increase in amount of stand alone H2 priests even if you
have priest-mages.