### PR TITLE
Clarification of montag adv. descs

### DIFF
--- a/src/nationGen/naming/NationAdvancedSummarizer.java
+++ b/src/nationGen/naming/NationAdvancedSummarizer.java
@@ -270,7 +270,7 @@ public class NationAdvancedSummarizer {
 			tw.println("Montag units:");
 			tw.println("--------------");
 			printUnits(tw, "montagmages", "Mages", n);
-			printUnits(tw, "montagsacreds", "Sacreds", n);
+			printUnits(tw, "montagsacreds", "Sacreds and Elites", n);
 			printUnits(tw, "montagtroops", "Troops", n);
 			tw.println();
 			


### PR DESCRIPTION
* Changed montag unit list label from "Sacreds" to "Sacreds and Elites" (I know there's enough info already there that this wasn't quite ambiguous, but it still managed to confuse some people)