### PR TITLE
Should've tested names more

### DIFF
--- a/data/names/nations/nordic/longsyllables.txt
+++ b/data/names/nations/nordic/longsyllables.txt
@@ -38,7 +38,7 @@ dra
 berg
 åle
 bre
-kir
+kirk
 leir
 lek
 kram

--- a/data/names/nations/nordic/longsyllables.txt
+++ b/data/names/nations/nordic/longsyllables.txt
@@ -8,6 +8,9 @@ djurs
 ek
 en
 eskils
+odins
+thors
+svens
 fager
 falken
 van
@@ -38,3 +41,9 @@ bre
 kir
 leir
 lek
+kram
+kors
+ny
+när
+salt
+vår

--- a/data/names/nations/nordic/shortsyllables.txt
+++ b/data/names/nations/nordic/shortsyllables.txt
@@ -1,10 +1,10 @@
 ke "cantbeafter consonant"
 van
 mun
-ö
+ö "cantbeafter ö"
 kul
 mar
-le
-lin
+s "cantbeafter s"
 no
-der
+er
+en

--- a/data/names/nations/nordic/shortsyllables.txt
+++ b/data/names/nations/nordic/shortsyllables.txt
@@ -1,7 +1,10 @@
 ke "cantbeafter consonant"
-nes
-dal
-stein
 van
 mun
-
+ö
+kul
+mar
+le
+lin
+no
+der


### PR DESCRIPTION

These ones are a bit better than previous ones:

Hedersand (= Honorsand) Bomarrus Lusand Kirkmarsand Falkenberg (= Falconmountain) Arnorus Saltgar Lilleberg (= Smallmountain) Enholm Thorssund (= Thor's sound) Saltborg (= Salt fortress) Margard Lekholm (Playisland (archaic form of island)) Falkenheim (Falconland) Nyarp Korsengard (Cross or dagger courtyard) Åleholm (Ale island) Kramvik (Embrace bay) Farsund (Father sound) Vanmunstad (Van mouth city) Vaxgard (Wax courtyard) Dranosund (Drain-o-sound) Narheim (Whenland) Odinsmunsand (Odin's mouth's sand) Draholm (Drain island) Ögard (Island courtyard) Kramhamn (Embrace harbour) Bollrus (Ballrus) Falkenping Kramheim (Embrace land) Luland Enerrus (Thousands rus) Luheim Korskulborg (Dagger fun fortress) Bosjo (Estate/Nest/To house/To live island) Bollhamn (Ball harbour) Draholm Ekholm (Oak island) Busheim (Mischiefland) Odinsengard (Odin's juniper wood courtyard) Enenheim (Poleland) Yfors Lusund Nyping Dranes Kramland Vaxrus Lillemark (Smallfield) Djursland (Animal's land) Borgard (To live courtyard)

Good pile of these have partial meanings, like "Y-rapids" or Mar-courtyard
