### PR TITLE
Troop naming update and misc changes and bugfixes

### DIFF
--- a/data/names/troopnaming/troopmiscguaranteedparts.txt
+++ b/data/names/troopnaming/troopmiscguaranteedparts.txt
@@ -7,6 +7,7 @@
 #chanceinc slotname armor 'medium clockwork armor' 1
 #chanceinc slotname armor 'heavy clockwork armor' 1
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -15,6 +16,7 @@
 #chanceinc slotname weapon standard 50
 #chanceinc slotname bonusweapon standard 50
 #chanceinc pose not infantry *0
+#neverredundant
 #end
 
 
@@ -24,6 +26,7 @@
 #basechance 0
 #themeinc thisitemslottag mount chariot 100
 #chanceinc pose not mounted *0
+#neverredundant
 #end
 
 
@@ -34,6 +37,7 @@
 #chanceinc slottag weapon 'mind' 1
 #chanceinc pose not ranged *0
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -42,6 +46,7 @@
 #chanceinc slottag weapon 'soul' 1
 #chanceinc pose not ranged *0
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -50,6 +55,7 @@
 #chanceinc slottag weapon 'spirit' 1
 #chanceinc pose not ranged *0
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -58,4 +64,6 @@
 #chanceinc slottag weapon 'will' 1
 #chanceinc pose not ranged *0
 #prefix
+#neverredundant
+#neverredundant
 #end

--- a/data/names/troopnaming/troopspecialprefixes.txt
+++ b/data/names/troopnaming/troopspecialprefixes.txt
@@ -5,6 +5,7 @@
 #chanceinc "unittheme slave 1000"
 #theme slave
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -14,6 +15,7 @@
 #chanceinc "unittheme gladiator 1000"
 #theme gladiator
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -23,6 +25,7 @@
 #chanceinc "unittheme militia 1000"
 #theme militia
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -33,6 +36,7 @@
 #theme militia
 #theme advanced
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -43,6 +47,7 @@
 #theme militia
 #theme primitive
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -52,6 +57,7 @@
 #chanceinc "unittheme elite 10"
 #theme elite
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -61,6 +67,7 @@
 #chanceinc "unittheme berserk 20"
 #theme berserk
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -70,6 +77,7 @@
 #chanceinc "unittheme irregular 1"
 #theme irregular
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -79,6 +87,7 @@
 #theme elite
 #theme commander
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -88,6 +97,7 @@
 #chanceinc "unittheme swamp 20"
 #theme swamp
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -97,6 +107,7 @@
 #chanceinc "unittheme swamp 20"
 #theme swamp
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -106,6 +117,7 @@
 #chanceinc "unittheme swamp 20"
 #theme swamp
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -115,6 +127,7 @@
 #chanceinc "unittheme swamp 10"
 #theme swamp
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -124,6 +137,7 @@
 #chanceinc "unittheme forest 20"
 #theme forest
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -133,6 +147,7 @@
 #chanceinc "unittheme forest 20"
 #theme forest
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -142,6 +157,7 @@
 #chanceinc "unittheme forest 10"
 #theme forest
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -152,6 +168,7 @@
 #chanceinc "nationcommand #idealcold above -1 *0"
 #theme forest
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -161,6 +178,7 @@
 #chanceinc "unittheme mountain 20"
 #theme mountain
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -170,6 +188,7 @@
 #chanceinc "unittheme mountain 20"
 #theme mountain
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -179,6 +198,7 @@
 #chanceinc "unittheme mountain 10"
 #theme mountain
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -188,6 +208,7 @@
 #chanceinc "unittheme mountain 10"
 #theme mountain
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -197,6 +218,7 @@
 #chanceinc "unittheme waste 20"
 #theme waste
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -207,6 +229,7 @@
 #chanceinc "nationcommand #idealcold above -1 *0"
 #theme waste
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -217,6 +240,7 @@
 #chanceinc "nationcommand #idealcold below 1 *0"
 #theme waste
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -227,6 +251,7 @@
 #chanceinc "percentageofcommand #flying 0.2 *0"
 #theme flying
 #prefix
+#neverredundant
 #end
 
 #new 
@@ -237,4 +262,5 @@
 #chanceinc "percentageofcommand #flying 0.2 *0"
 #theme flying
 #prefix
+#neverredundant
 #end

--- a/documentation/special_commands.txt
+++ b/documentation/special_commands.txt
@@ -384,3 +384,13 @@ Uses this name instead if race/pose has given tag.
 
 #commandvariant <command> [positive/negative] <name>
 Uses this name instead if unit has given command. Positive/negative can be used to require a negative or a positive value for the command (such as #fireres)
+
+-- Troop naming
+#neverredundant 
+If this is on a troop name, it will not be removed (it may be replaced though). Meaningful only on prefix / prefixprefix for files that 
+are run in differentiation naming mode: weaponname and miscitemprefixes.
+
+#type <type>
+No two name parts of same type should appear
+
+

--- a/src/nationGen/magic/MageGenerator.java
+++ b/src/nationGen/magic/MageGenerator.java
@@ -349,12 +349,15 @@ public class MageGenerator extends TroopGenerator {
 		// A setting here is probably a good idea as well.
 		if(secondaries > 1)
 		{
+			List<MagicPattern> derp = new ArrayList<MagicPattern>();
 			int lowlim = 2;
-			while(secs.size() == 0 || lowlim == 2 && lowlim < 12)
+			while((derp.size() == 0 && random.nextBoolean()) || lowlim == 2 && lowlim < 12)
 			{
-				secs = getPatternsWithSpread(secs, 0, lowlim);
+				derp = getPatternsWithSpread(secs, 0, lowlim);
 				lowlim++;
 			}
+			
+			secs = derp;
 		}
 
 		if(secs.size() == 0)
@@ -403,9 +406,8 @@ public class MageGenerator extends TroopGenerator {
 		int maxSpread = 8;
 		if(tertiaries == secondaries)
 			for(MagicPattern p : secondarypatterns)
-				if(p.getPathsAtleastAt(1) < maxSpread)
-					maxSpread = p.getPathsAtleastAt(1);
-		
+				if(p.getPathsAtleastAt(1) + 1 < maxSpread)
+					maxSpread = p.getPathsAtleastAt(1) + 1;
 		
 		
 		List<MagicPattern> terts = getPatternsWithPicks(this.getPatternsForTier(1, primaries), 0, maxPicks);

--- a/src/nationGen/magic/MageGenerator.java
+++ b/src/nationGen/magic/MageGenerator.java
@@ -477,7 +477,7 @@ public class MageGenerator extends TroopGenerator {
 
 				
 				
-				double slowrecmod = mages.get(i).get(j).getMagicAmount(0.25) / 8 + 0.25;
+				double slowrecmod = mages.get(i).get(j).getMagicAmount(0.25) / 10 + 0.25;
 			
 				int highpicks = all.get(i).get(j).getPathsAtleastAt(3, 0.25);
 				if(highpicks > 2)
@@ -494,8 +494,6 @@ public class MageGenerator extends TroopGenerator {
 				{
 					mages.get(i).get(j).caponly = true;
 				}
-				else if(i == 2)
-					slowrecmod *= 1.5;
 
 				if(slowrecrand < slowrecmod && i == 2)
 				{
@@ -2709,7 +2707,7 @@ public class MageGenerator extends TroopGenerator {
 		{
 			
 			double picks = u.getMagicAmount(20);
-			double limit = 0.1 + (picks - 2) * 0.2; 
+			double limit = 0.05 + (picks - 2) * 0.1; 
 			if(picks < 4)
 				limit = 0;
 			
@@ -2719,15 +2717,15 @@ public class MageGenerator extends TroopGenerator {
 			}
 			else if(picks > 6)
 			{
-				u.commands.add(new Command("#older", "-15"));
+				u.commands.add(new Command("#older", "-20"));
 			}
 			else if(picks > 5)
 			{
-				u.commands.add(new Command("#older", "-10"));
+				u.commands.add(new Command("#older", "-15"));
 			}
 			else if(picks > 4)
 			{
-				u.commands.add(new Command("#older", "-5"));
+				u.commands.add(new Command("#older", "-10"));
 			}
 
 		}

--- a/src/nationGen/misc/ChanceIncHandler.java
+++ b/src/nationGen/misc/ChanceIncHandler.java
@@ -30,6 +30,7 @@ import com.elmokki.Generic;
 
 
 
+
 import nationGen.entities.Entity;
 import nationGen.entities.Filter;
 import nationGen.entities.Pose;
@@ -1969,7 +1970,6 @@ public class ChanceIncHandler {
 				}
 				else if(args.get(0).equals("slot") && args.size() > 3)
 				{
-
 					boolean not = args.contains("not");
 					boolean armor = args.contains("armor");
 					boolean weapon = args.contains("weapon");
@@ -1977,18 +1977,28 @@ public class ChanceIncHandler {
 					Item i = u.getSlot(args.get(args.size() - 3));
 					if(i != null)
 					{
+					
 						if(i.id.equals(args.get(args.size() - 2)))
 						{
 							contains = true;
 						}
 						else if(i.getClass() == CustomItem.class)
 						{
+				
 							CustomItem ci = (CustomItem)i;
 							if(ci.olditem != null && ci.olditem.id != null && ci.olditem.id.equals(args.get(args.size() - 2)))
 							{
 								contains = true;
 							}
+							else if((Integer.parseInt(i.id) >= 700 && !i.armor) || ((Integer.parseInt(i.id) >= 250 && i.armor)))
+							{
+								if(Generic.containsTag(i.tags, "OLDID") && Generic.getTagValue(i.tags, "OLDID").equals(args.get(args.size() - 2)))
+								{
+									contains = true;
+								}
+							}
 						}
+				
 						
 						if(contains)
 						{

--- a/src/nationGen/naming/Name.java
+++ b/src/nationGen/naming/Name.java
@@ -17,6 +17,7 @@ public class Name  {
 	public NamePart rankprefix;
 	public NamePart prefix;
 	public NamePart prefixprefix;
+	public NamePart prefixprefixprefix;
 	public NamePart suffixprefix;
 	public NamePart suffix;
 	
@@ -37,6 +38,10 @@ public class Name  {
 	public void setPrefixprefix(String str)
 	{
 		this.prefixprefix = NamePart.newNamePart(str, null);
+	}
+	public void setPrefixprefixprefix(String str)
+	{
+		this.prefixprefixprefix = NamePart.newNamePart(str, null);
 	}
 	public void setSuffixprefix(String str)
 	{
@@ -63,6 +68,7 @@ public class Name  {
 	{
 		Name name = new Name();
 		name.rankprefix = rankprefix;
+		name.prefixprefixprefix = prefixprefixprefix;
 		name.prefixprefix = prefixprefix;
 		name.prefix = prefix;
 		name.type = type;
@@ -81,7 +87,8 @@ public class Name  {
 		
 		if(rankprefix != null)
 			str = str + rankprefix.toString(u) + " ";
-		
+		if(prefixprefixprefix != null)
+			str = str + prefixprefixprefix.toString(u) + " ";
 		if(prefixprefix != null)
 			str = str + prefixprefix.toString(u) + " ";
 		if(prefix != null)
@@ -105,7 +112,6 @@ public class Name  {
 		if(str.endsWith(" "))
 			str = str.substring(0, str.length() - 1);
 		
-		
 
 		return NameGenerator.capitalize(str);
 	}
@@ -120,13 +126,19 @@ public class Name  {
 		String str = "";
 		if(rankprefix != null)
 			str = str + rankprefix + " ";
+		
+		if(prefixprefixprefix != null)
+			str = str + prefixprefixprefix + " ";
+		
 		if(prefixprefix != null)
 			str = str + prefixprefix + " ";
+		
 		if(prefix != null)
 			str = str + prefix + " ";
 		
 		if(suffixprefix != null)
 			str = str + suffixprefix + " ";
+		
 		if(suffix != null)
 			str = str + suffix + " ";
 		
@@ -158,6 +170,7 @@ public class Name  {
 		list.add(suffixprefix);
 		list.add(suffix);
 		
+		list.remove(null);
 		list.remove(null);
 		list.remove(null);
 		list.remove(null);

--- a/src/nationGen/naming/NamePart.java
+++ b/src/nationGen/naming/NamePart.java
@@ -145,6 +145,10 @@ public class NamePart extends Filter {
 		part.weak = this.weak;
 		part.elements.addAll(this.elements);
 		part.minimumelements = this.minimumelements;
+		part.types.addAll(this.types);
+		part.tags.addAll(this.tags);
+		part.themes.addAll(this.themes);
+
 		return part;
 	}
 	

--- a/src/nationGen/naming/TroopNamer.java
+++ b/src/nationGen/naming/TroopNamer.java
@@ -90,6 +90,9 @@ public class TroopNamer {
 			u.name.setType(Generic.getTagValue(Generic.getAllUnitTags(u), "forcedname"));
 		}
 		
+		// Give special parts
+		setGuaranteedParts(alltroops, specialnames);
+		setGuaranteedParts(alltroops, specialprefixes);
 		
 		// Give misc guaranteed parts
 		setGuaranteedParts(alltroops, miscguaranteed);
@@ -113,9 +116,7 @@ public class TroopNamer {
 		removeRedundantParts(n.combineTroopsToList("montagtroops"));
 
 	
-		// Give special parts
-		setGuaranteedParts(alltroops, specialnames);
-		setGuaranteedParts(alltroops, specialprefixes);
+
 		
 		// National prefix/suffix
 		addNationalPrefix(alltroops);

--- a/src/nationGen/naming/TroopNamer.java
+++ b/src/nationGen/naming/TroopNamer.java
@@ -131,8 +131,6 @@ public class TroopNamer {
 		addNationPrefix(alltroops);
 				
 
-		for(Unit u : n.generateTroopList())
-			System.out.println(u.name);
 		
 		nameCommanders(n);
 		
@@ -711,7 +709,7 @@ public class TroopNamer {
 			if(part != null)
 			{
 				setNamePart(u, part);
-
+				
 			}
 			
 			

--- a/src/nationGen/naming/TroopNamer.java
+++ b/src/nationGen/naming/TroopNamer.java
@@ -78,7 +78,7 @@ public class TroopNamer {
 		alltroops.addAll(n.combineTroopsToList("ranged"));
 		alltroops.addAll(n.combineTroopsToList("montagtroops"));
 
-		
+	
 		// #forcedname
 		List<Unit> forcednames = new ArrayList<Unit>();
 		for(Unit u : alltroops)
@@ -100,14 +100,22 @@ public class TroopNamer {
 		parts.addAll(miscitemprefixes);
 		differentiateNames(alltroops, parts);
 		
-		// Give special parts
-		setGuaranteedParts(alltroops, specialnames);
-		setGuaranteedParts(alltroops, specialprefixes);
-		
+
 		// If we have overwritten a prefix we may want to differentiate infantry with weapon names
 		differentiateNames(n.combineTroopsToList("infantry"), weaponnames);
 		differentiateNames(n.combineTroopsToList("montagtroops"), weaponnames);
+		
 
+		// Remove as much as we can to keep things simple
+		removeRedundantParts(n.combineTroopsToList("infantry"));
+		removeRedundantParts(n.combineTroopsToList("mounted"));
+		removeRedundantParts(n.combineTroopsToList("ranged"));
+		removeRedundantParts(n.combineTroopsToList("montagtroops"));
+
+	
+		// Give special parts
+		setGuaranteedParts(alltroops, specialnames);
+		setGuaranteedParts(alltroops, specialprefixes);
 		
 		// National prefix/suffix
 		addNationalPrefix(alltroops);
@@ -117,7 +125,13 @@ public class TroopNamer {
 		addHeavyLightPrefix(n.combineTroopsToList("mounted"));
 		addHeavyLightPrefix(n.combineTroopsToList("ranged"));
 		addHeavyLightPrefix(n.combineTroopsToList("montagtroops"));
+		
+		// Nation name ("Ulmish" etc)
+		addNationPrefix(alltroops);
+				
 
+		for(Unit u : n.generateTroopList())
+			System.out.println(u.name);
 		
 		nameCommanders(n);
 		
@@ -125,6 +139,14 @@ public class TroopNamer {
 	
 	
 
+	private void addNationPrefix(List<Unit> units)
+	{
+		for(Unit unit : units)
+		{
+			unit.name.setRankPrefix(Generic.capitalize(n.name) + n.nationalitysuffix);
+		}
+	}
+	
 
 	private void addHeavyLightPrefix(List<Unit> units)
 	{
@@ -137,13 +159,21 @@ public class TroopNamer {
 					if(unit.getTotalProt() < named.getTotalProt() && named.isHeavy())
 					{
 						String part = "Heavy";
-						named.name.setRankPrefix(part);
+						if(named.name.prefixprefix == null)
+							named.name.setPrefixprefix(part);
+						else
+							named.name.setPrefixprefixprefix(part);
 						break;
 					}
 					else if(unit.getTotalProt() > named.getTotalProt() && named.isLight())
 					{
 						String part = "Light";
-						named.name.setRankPrefix(part);
+						
+						if(named.name.prefixprefix == null)
+							named.name.setPrefixprefix(part);
+						else
+							named.name.setPrefixprefixprefix(part);
+						
 						break;
 					}
 
@@ -155,15 +185,10 @@ public class TroopNamer {
 	private void addNationalPrefix(List<Unit> units)
 	{
 
-	
-		
+
 		for(Unit u : units)
 		{
-
-			
 			String part = "";
-			
-	
 			if(!u.race.visiblename.equals(n.races.get(0).visiblename))
 			{
 				part = u.race.visiblename;
@@ -533,7 +558,8 @@ public class TroopNamer {
 							if(p2 != null && p2.types.contains(t))
 								pointlessParts.add(p);
 				
-
+				
+				
 				for(NamePart p : possibleParts)
 				{
 					
@@ -563,6 +589,8 @@ public class TroopNamer {
 					
 				possibleParts.removeAll(pointlessParts);
 				possibleParts.removeAll(u.name.getAsNamePartList());
+				
+				
 				// If we have possible parts, set one.
 				if(possibleParts.size() > 0)
 				{
@@ -581,12 +609,80 @@ public class TroopNamer {
 							setNamePart(u2, p);
 						}
 					}
+					
+					
 				}
 					
 				
 			}
 			
 		}
+	}
+	
+	private void removeRedundantParts(List<Unit> units)
+	{
+		
+		// Prefix prefix
+		for(Unit u : units)
+		{
+
+			if(u.name.prefixprefix == null)
+				continue;
+			
+			Name ntemp = u.name.getCopy();
+			ntemp.prefixprefix = null;
+			boolean canremove = true;
+			
+			for(Unit u2 : units)
+			{
+				Name ntemp2 = u2.name.getCopy();
+				ntemp2.prefixprefix = null;
+			
+				if(ntemp2.toString().equals(ntemp.toString()) && u != u2)
+				{
+					canremove = false;
+				}
+			}
+			if(canremove && !Generic.containsTag(u.name.prefixprefix.tags, "neverredundant"));
+			{
+				u.name.prefixprefix = null;
+			}
+			
+			
+		}
+		
+		
+		// Prefix
+		for(Unit u : units)
+		{
+
+			if(u.name.prefix == null)
+				continue;
+			
+			Name ntemp = u.name.getCopy();
+			ntemp.prefix = null;
+			boolean canremove = true;
+			
+			for(Unit u2 : units)
+			{
+				Name ntemp2 = u2.name.getCopy();
+				ntemp2.prefix = null;
+				
+				if(ntemp2.toString().equals(ntemp.toString())  && u != u2)
+				{
+					canremove = false;
+				}
+			}
+			if(canremove && !Generic.containsTag(u.name.prefix.tags, "neverredundant"))
+			{
+				u.name.prefix = null;
+			}
+			
+		}
+
+
+
+		
 	}
 	
 	private void setGuaranteedParts(List<Unit> units, List<NamePart> all)

--- a/src/nationGen/units/Unit.java
+++ b/src/nationGen/units/Unit.java
@@ -25,9 +25,11 @@ import javax.imageio.ImageIO;
 
 
 
+
 import com.elmokki.Dom3DB;
 import com.elmokki.Drawing;
 import com.elmokki.Generic;
+
 
 
 
@@ -928,6 +930,7 @@ public class Unit {
 			{
 
 				Item ti = i.getCopy();
+				ti.tags.add("OLDID " + i.id);
 				ti.id = nationGen.getCustomItemId(i.id);
 				this.setSlot(str, ti);
 			}


### PR DESCRIPTION
Troop naming now:
- Adds nationality prefix ("Ulmish") since units tend to have identical names across nations so often.
- Tries to shorten names when there's redundancy in item based names

Example of the second: You have three "Spear Warrior" named units after first weapon set. The program differentiates them to "Spear Javelineer", "Spear Warrior" and "Spear Axe Thrower". This look stupid. Now the program will check whether removing prefix (or prefixprefix) on any pair results in duplicates. Since Warrior != Axe Thrower != Javelineer, the program removes all prefixes. 

However, if the nation also had an "Axe Warrior", the "Spear Warrior" would keep the name since Warrior = Warrior.

I changed the order of resolving things somewhat too.