### PR TITLE
Tweaking fake chariot names

### DIFF
--- a/data/names/troopnaming/troopmiscguaranteedparts.txt
+++ b/data/names/troopnaming/troopmiscguaranteedparts.txt
@@ -24,7 +24,7 @@
 #new 
 #name "chariot"
 #basechance 0
-#themeinc thisitemslottag mount chariot 100
+#chanceinc slottag mount chariot 100
 #chanceinc pose not mounted *0
 #neverredundant
 #end


### PR DESCRIPTION
* This should hopefully be more correct in doing what is intended with faux-chariot mounted units; I presume that this is where the "pale one chariot" came from, even though I couldn't duplicate the bug
* I probably should just give in and make these into proper chariot poses instead of cutting corners since it's now swan AND rat chariots (and could easily be expanded to goat and pig "small chariots", too), but for now I'll leave it in its kludged form