### PR TITLE
Illi thralls turned on, winged olm FS

### DIFF
--- a/data/items/foulspawn/mounted/legs.txt
+++ b/data/items/foulspawn/mounted/legs.txt
@@ -181,10 +181,35 @@
 #define "#enc 4"
 #define "#rcost +4"
 #define "#coldblooded"
-#define "#amphibious"
+#define "#amphibian"
 #define "#poisonres +10"
 #tag "animal worm"
 #define "#maxage *1.25"
+#enditem
+
+#newitem
+#name "olm_winged"
+#gameid -1
+#sprite /graphics/foulspawn/centauroid/legs/olm.png
+#offsetx 1
+#offsety -4
+#needs overlay goat_winged
+#needs underlay goat_winged
+#define "#size 4"
+#define "#hp +8"
+#define "#prot +0"
+#define "#def -2"
+#define "#mapmove 3"
+#define "#ap 6"
+#define "#gcost +15"
+#define "#ressize 2"
+#define "#enc 4"
+#define "#rcost +5"
+#define "#amphibian"
+#define "#flying"
+#define "#poisonres +5"
+#define "#gcost +15"
+#tag "animal worm"
 #enditem
 
 #newitem
@@ -229,7 +254,7 @@
 #define "#weapon 85"
 #define "#weapon 85"
 #define "#heal"
-#define "#amphibious"
+#define "#amphibian"
 #itemslot misc +1
 #define "#maxage *1.25"
 #enditem

--- a/data/poses/poses.txt
+++ b/data/poses/poses.txt
@@ -166,11 +166,12 @@
 #load foulspawncavalry ./data/poses/foulspawn/small/cavalry.txt
 #load foulspawnmages ./data/poses/foulspawn/small/mages.txt
 
----- Illithids and various hybrids
+---- Illithids, various hybrids, and illithid-specific slave units
 #load hybridtroops ./data/poses/illithid/hybrid_infantry.txt
 #load hybridcavalry ./data/poses/illithid/hybrid_cavalry.txt
 #load starchildtroops ./data/poses/illithid/starchild_troops.txt
 #load starchildmages ./data/poses/illithid/starchild_mages.txt
+#load illithidslaves ./data/poses/illithid/slaves.txt
 
 ---- Ogres and related oversized humanoids
 #load ogretroops ./data/poses/ogre/infantry_ogre.txt

--- a/data/races/illithid.txt
+++ b/data/races/illithid.txt
@@ -13,6 +13,7 @@
 #pose hybridcavalry
 #pose starchildtroops
 #pose starchildmages
+#pose illithidslaves
 
 #generationchance mounted 0.05
 


### PR DESCRIPTION
* Turned on the illi thralls that have been added. They're there, so there's no reason not to add them even if it means that some secondary races are better than others for the starkids
* Added winged olm-centeroid FS: because why not?
* Fixed a few instances of #amphibious -> #amphibian, because if I didn't periodically but consistently make these sorts of typos it just wouldn't be the same