### PR TITLE
Better leadership for warrior-mages/priests

### DIFF
--- a/data/poses/agarthan/agarthanmages.txt
+++ b/data/poses/agarthan/agarthanmages.txt
@@ -33,6 +33,7 @@
 #name ancient_caster
 #role "mage"
 #role "priest"
+#warriormage
 
 #command "#coldblood"
 #subrace "ancient one"
@@ -62,6 +63,7 @@
 #basechance 0.1
 #role "mage"
 #role "priest"
+#warriormage
 
 #subrace "olmspawn"
 #subraceprefix "olmspawn"

--- a/data/poses/amazon/amazonmage.txt
+++ b/data/poses/amazon/amazonmage.txt
@@ -40,6 +40,7 @@
 #role "mage"
 #name "warrior-mage"
 #basechance 0.15
+#warriormage
 
 #tier 1
 #tier 2
@@ -79,6 +80,7 @@
 #role "elite"
 #name "warrior-mage_mounted"
 #basechance 0.15  
+#warriormage
 
 #tier 1
 #tier 2
@@ -124,6 +126,7 @@
 #role "priest"
 #name "warrior-priestess"
 #basechance 0.25
+#warriormage
 
 #tier 1
 #tier 2
@@ -162,6 +165,7 @@
 #role "elite"
 #name "warrior-priestess_mounted"
 #basechance 0.25
+#warriormage
 
 #tier 1
 #tier 2

--- a/data/poses/atlantian/mages.txt
+++ b/data/poses/atlantian/mages.txt
@@ -9,6 +9,7 @@
 #subrace "shambler"
 #subraceprefix "shambler"
 #command "#amphibian"
+#warriormage
 
 #load basesprite /data/items/atlantian/shamblerpriestbases.txt
 #load shadow /data/items/atlantian/shamblershadow.txt

--- a/data/poses/fomorian/giants.txt
+++ b/data/poses/fomorian/giants.txt
@@ -40,6 +40,7 @@
 #role "mage"
 #subrace giant
 #subraceprefix "giant"
+#warriormage
 
 #renderorder "shadow extra1 cloakb basesprite legs shirt armor cloakf bonusweapon weapon offhandw hands hair helmet offhanda"
 

--- a/data/poses/halfmen/minotaurmages.txt
+++ b/data/poses/halfmen/minotaurmages.txt
@@ -5,6 +5,7 @@
 #name "tier 1 hot-headed youth"
 #role "mage"
 #role "priest"
+#warriormage
 
 #theme "minotaur"
 

--- a/data/poses/monkey/vanaraelders.txt
+++ b/data/poses/monkey/vanaraelders.txt
@@ -8,6 +8,7 @@
 #theme "abysian"
 #theme "imperial"
 #theme "oriental"
+#warriormage
 
 #command "#gcost +10"
 #command "#hp +2"

--- a/data/poses/muuch/mages.txt
+++ b/data/poses/muuch/mages.txt
@@ -29,6 +29,7 @@
 #name "shambler casters"
 #role "mage"
 #role "priest"
+#warriormage
 
 #notfortier 1
 #tier 2

--- a/data/poses/sidhe/mages.txt
+++ b/data/poses/sidhe/mages.txt
@@ -8,6 +8,7 @@
 -- #renderorder "shadow cloakb basesprite legs shirt armor cloakf bonusweapon weapon offhandw hair helmet offhanda"
 #tier 1
 #tier 2
+#warriormage
 
 #define "#stealthy 0"
 
@@ -38,6 +39,7 @@
 -- #renderorder "shadow cloakb mount basesprite legs shirt armor cloakf bonusweapon weapon offhandw hair helmet offhanda overlay"
 #tier 2
 #tier 3
+#warriormage
 
 #define "#stealthy 0"
 
@@ -68,6 +70,7 @@
 -- #renderorder "shadow cloakb mount basesprite legs shirt armor cloakf bonusweapon weapon offhandw hair helmet offhanda"
 #tier 2
 #tier 3
+#warriormage
 
 #define "#stealthy 0"
 

--- a/data/poses/vanir/mages.txt
+++ b/data/poses/vanir/mages.txt
@@ -6,6 +6,7 @@
 #name "Tier 2-3 mages"
 #renderorder "shadow cloakb mount basesprite legs shirt armor cloakf bonusweapon weapon offhandw hands beard hair helmet offhanda overlay extra1 extra2 extra3"
 #load basesprite /data/items/nordic/normal/bases.txt
+#warriormage
 
 
 #load hands /data/items/human/normal/humanhands.txt 0 -3

--- a/src/nationGen/magic/MageGenerator.java
+++ b/src/nationGen/magic/MageGenerator.java
@@ -464,14 +464,50 @@ public class MageGenerator extends TroopGenerator {
 				mages.get(i).get(j).name.setType(all.get(i).get(j).toString(derp));
 				
 			
-				
-				
-				if(i == 2 && leaderrandom1 > 0.9)
-					mages.get(i).get(j).commands.add(new Command("#goodleader"));
-				else if(i == 2 && leaderrandom1 > 0.6){/*do nothing*/}
-				else if(i == 1 && leaderrandom1 > 0.9 && leaderrandom2 > 0.5){/*do nothing*/}
+				if(mages.get(i).get(j).tags.contains("warriormage"))
+				{
+					if(leaderrandom1 > 0.95)
+					{
+						mages.get(i).get(j).commands.add(new Command("#expertleader"));
+						mages.get(i).get(j).commands.add(new Command("#gcost +50"));
+					}
+					else if(leaderrandom1 > 0.8)
+					{
+						mages.get(i).get(j).commands.add(new Command("#goodleader"));
+						mages.get(i).get(j).commands.add(new Command("#gcost +30"));
+					}
+					else if(leaderrandom1 > 0.5)
+					{
+						mages.get(i).get(j).commands.add(new Command("#okayleader"));
+						mages.get(i).get(j).commands.add(new Command("#command +20"));
+						mages.get(i).get(j).commands.add(new Command("#gcost +10"));
+					}
+					else if(leaderrandom1 > 0.25)
+					{
+						mages.get(i).get(j).commands.add(new Command("#okayleader"));
+					}
+					else if(leaderrandom1 > 0.0625)
+					{
+						mages.get(i).get(j).commands.add(new Command("#poorleader"));
+						mages.get(i).get(j).commands.add(new Command("#command +30"));
+					}
+					else
+					{
+						mages.get(i).get(j).commands.add(new Command("#poorleader"));
+						mages.get(i).get(j).commands.add(new Command("#gcost -5"));
+					}
+
+				}
+					
 				else
-					mages.get(i).get(j).commands.add(new Command("#poorleader"));
+				{
+					if(i == 2 && leaderrandom1 > 0.9)
+						mages.get(i).get(j).commands.add(new Command("#goodleader"));
+					else if(i == 2 && leaderrandom1 > 0.6){/*do nothing*/}
+					else if(i == 1 && leaderrandom1 > 0.9 && leaderrandom2 > 0.5){/*do nothing*/}
+					else
+						mages.get(i).get(j).commands.add(new Command("#poorleader"));
+				}
 
 					
 					
@@ -1427,8 +1463,41 @@ public class MageGenerator extends TroopGenerator {
 				if(r.nextDouble() > 0.9)
 					u.commands.add(new Command("#slowrec"));
 			}
-			
-			if(currentStrength == 3 && r.nextDouble() > 0.75){/*do nothing*/}
+
+			if(u.tags.contains("warriormage"))
+			{
+				double leaderrandom = r.nextDouble();
+				if(leaderrandom > 0.95)
+				{
+					u.commands.add(new Command("#expertleader"));
+					u.commands.add(new Command("#gcost +80"));
+				}
+				else if(leaderrandom > 0.8)
+				{
+					u.commands.add(new Command("#goodleader"));
+					u.commands.add(new Command("#gcost +40"));
+				}
+				else if(leaderrandom > 0.5)
+				{
+					u.commands.add(new Command("#okayleader"));
+					u.commands.add(new Command("#command +20"));
+					u.commands.add(new Command("#gcost +20"));
+				}
+				else if(leaderrandom > 0.25)
+				{
+					u.commands.add(new Command("#okayleader"));
+					u.commands.add(new Command("#gcost +10"));
+				}
+				else if(leaderrandom > 0.0675)
+				{
+					u.commands.add(new Command("#poorleader"));
+					u.commands.add(new Command("#command +30"));
+					u.commands.add(new Command("#gcost +5"));
+				}
+				else
+					u.commands.add(new Command("#poorleader"));
+			}
+			else if(currentStrength == 3 && r.nextDouble() > 0.75){/*do nothing*/}
 			else if(currentStrength == 2 && r.nextDouble() > 0.85){/*do nothing*/}
 			else
 			{


### PR DESCRIPTION
* Casters with the "warriormage" tag will get leadership ranging from 10 to 120, with (slightly discounted) gcost bumps according to the standard scale of costs; about 3/4s of them will have leadership falling between 10+30 and 40+20
* Currently warrior-mages include some  (or in a few cases, all) varieties of: pale ones, amazons, Atlantians, muuch. Fomorian giants, minotaurs. vanara, vanir, and sidhe