### PR TITLE
Montag id handling fix

### DIFF
--- a/src/nationGen/NationGen.java
+++ b/src/nationGen/NationGen.java
@@ -16,6 +16,7 @@ import java.io.PrintWriter;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Random;
 import java.util.Scanner;
@@ -838,12 +839,17 @@ public class NationGen {
 		
 		for(Unit u : units)
 			for(Command c : u.commands)
+			{	
 				if(c.command.contains("shape") && !hasShapeShift(c.args.get(0)))
 				{
-					if(c.command.equals("#firstshape") && u.tags.contains("montagunit"));
+					if((c.command.equals("#firstshape") && u.tags.contains("montagunit")))
+						handleMontag(c, u, units);
 					else
 						handleShapeshift(c, u);
 				}
+				else if(c.command.equals("#montag"))
+					handleMontag(c, u, units);
+			}	
 		
 		
 	
@@ -886,6 +892,27 @@ public class NationGen {
 
 		
 		
+
+	}
+	
+	
+	private HashMap<String, Integer> montagmap = new HashMap<String, Integer>();
+	private void handleMontag(Command c, Unit u, List<Unit> units)
+	{
+		Integer montag = montagmap.get(c.args.get(0));
+		if(montag == null)
+		{
+
+			montag = idHandler.nextMontagId();
+			montagmap.put(c.args.get(0), montag);
+			System.out.println("Added "  + montag + " for " + c.args.get(0));
+
+		}
+		
+		if(c.command.equals("#firstshape"))
+			c.args.set(0, "-" + montag);
+		else if(c.command.equals("#montag"))
+			c.args.set(0, "" + montag);
 
 	}
 	

--- a/src/nationGen/nation/Nation.java
+++ b/src/nationGen/nation/Nation.java
@@ -59,6 +59,8 @@ import nationGen.units.Unit;
 
 
 public class Nation {
+	
+	public int mockid = -2;
 	public Color[] colors = new Color[5];
 	public int nationid;
 	public int era = 2;

--- a/src/nationGen/rostergeneration/UnitGen.java
+++ b/src/nationGen/rostergeneration/UnitGen.java
@@ -48,7 +48,6 @@ public class UnitGen {
 	
 	
 	
-	
 	public UnitGen(NationGen gen, Nation n)
 	{
 		this.nationGen = gen;
@@ -994,13 +993,13 @@ public class UnitGen {
 
 		if(list.size() > 0)
 		{
-			int montag = nationGen.idHandler.nextMontagId();
+			String montag = "montag" + nation.nationid + "_" + nation.mockid--;
 			for(Unit nu : list)
 			{
 				nu.tags.add("hasmontag");
 				nu.commands.add(new Command("#montag", ""+montag));
 			}
-			u.commands.add(new Command("#firstshape", "-"+montag));
+			u.commands.add(new Command("#firstshape", ""+montag));
 			u.tags.add("montagunit");
 		}
 				
@@ -1055,20 +1054,25 @@ public class UnitGen {
 	{
 
 		List<Unit> units = new ArrayList<Unit>();
-		if(Generic.containsTag(u.pose.tags, "montagpose") && !Generic.containsTag(u.pose.tags, "no_montag_mean_costs") && u.getCommandValue("#firstshape", 0) < 0)
+		if(Generic.containsTag(u.pose.tags, "montagpose"))
 		{
 	
-			int firstshape = -u.getCommandValue("#firstshape", 0);
+			String firstshape = u.getStringCommandValue("#firstshape", "");
+			boolean numeric = Generic.isNumeric(firstshape);
+			
+			
 			for(List<Unit> lu : nation.unitlists.values())
 			{
 				for(Unit nu : lu)
-					if(nu.getCommandValue("#montag", 0) == firstshape && u != nu)
-					{
+				{	
+					if(!numeric && nu.getStringCommandValue("#montag", "").equals(firstshape) && u != nu)
 						units.add(nu);
-				
-					}
+					else if(numeric && ("-" + nu.getStringCommandValue("#montag", "")).equals(firstshape))
+						units.add(nu);
+					
+					
+				}	
 			}
-			
 
 			
 				

--- a/src/nationGen/units/Unit.java
+++ b/src/nationGen/units/Unit.java
@@ -1218,17 +1218,17 @@ public class Unit {
 		
 
 		// Montag mean costs
-		if(Generic.containsTag(this.pose.tags, "montagpose") && !Generic.containsTag(this.pose.tags, "no_montag_mean_costs") && getCommandValue("#firstshape", 0) < 0)
+		if(Generic.containsTag(this.pose.tags, "montagpose") && !Generic.containsTag(this.pose.tags, "no_montag_mean_costs"))
 		{
 			int n = 0;
 			int res = 0;
 			int gold = 0;
 			
-			int firstshape = -getCommandValue("#firstshape", 0);
+			String firstshape = getStringCommandValue("#firstshape", "");
 			for(List<Unit> lu : nation.unitlists.values())
 			{
 				for(Unit nu : lu)
-					if(nu.getCommandValue("#montag", 0) == firstshape && u != nu)
+					if(nu.getStringCommandValue("#montag", "").equals(firstshape) && u != nu)
 					{
 						nu.polish();
 						res += nu.getResCost(true);
@@ -1673,6 +1673,18 @@ public class Unit {
 		}
 		return value;
 	}
+	
+	public String getStringCommandValue(String command, String defaultv)
+	{
+		String value = defaultv;
+		for(Command c : this.getCommands())
+		{
+			if(c.command.equals(command) && c.args.size() > 0)
+				value = c.args.get(0);
+		}
+		return value;
+	}
+	
 	
 	// 20150522EA : my OOP prof back in undergrad would probably shoot me for this method...
 	public void setCommandValue(String command, int argIndex, String newValue)


### PR DESCRIPTION
Ids were being handled during generation, resulting in theoretical
ability to run out of ids if a very large amount of montag units were
generated in discarded nations.

Now there's a mock id of type "nationX_-Y" being handed and actual
montag ids being given when shapeshift ids are being given.