### PR TITLE
Illithid subrace improvements, nephilm go on a diet

### DIFF
--- a/data/items/avvim/nephilim/bases.txt
+++ b/data/items/avvim/nephilim/bases.txt
@@ -21,7 +21,7 @@
 #command "#fear 5"
 #command "#supplybonus -50"
 #command "#incunrest 12"
-#command "#popkill 120"
+#command "#popkill 12"
 #command "#holy"
 #command "#neednoteat"
 #command "#wastesurvival"

--- a/data/poses/illithid/illithid_mages.txt
+++ b/data/poses/illithid/illithid_mages.txt
@@ -26,7 +26,6 @@
 #command "#magicbeing"
 #command "#amphibian"
 #command "#weapon 86"
-#subrace illithid
 #command "#descr 'Illithids are pink masses of writhing tentacles, said to be from a distant star.'"
 
 #renderorder "shadow color pattern trim armor basesprite weapon offhandw hands helmet offhanda"
@@ -88,7 +87,6 @@
 #command "#magicbeing"
 #command "#amphibian"
 #command "#weapon 86"
-#subrace illithid
 #command "#descr 'Illithids are pink masses of writhing tentacles, said to be from a distant star.'"
 
 #strongmagicpatterns
@@ -153,7 +151,6 @@
 #command "#magicbeing"
 #command "#amphibian"
 #command "#weapon 86"
-#subrace illithid
 #command "#descr 'Illithids are pink masses of writhing tentacles, said to be from a distant star.'"
 
 #weakmagicpatterns

--- a/data/poses/illithid/illithid_troops.txt
+++ b/data/poses/illithid/illithid_troops.txt
@@ -26,7 +26,6 @@
 #command "#bluntres"
 #command "#magicbeing"
 #command "#amphibian"
-#subrace illithid
 #command "#descr 'Illithids are pink masses of writhing tentacles, said to be from a distant star.'"
 #tag "noble"
 
@@ -83,7 +82,6 @@
 #command "#bluntres"
 #command "#magicbeing"
 #command "#amphibian"
-#subrace illithid
 #command "#descr 'Illithids are pink masses of writhing tentacles, said to be from a distant star.'"
 #tag "noble"
 

--- a/data/poses/illithid/slaves.txt
+++ b/data/poses/illithid/slaves.txt
@@ -2,6 +2,7 @@
 #newpose
 #name "pale one thrall"
 #role "infantry"
+#subrace "pale one"
 
 #basechance 0
 #chanceinc "secondaryrace 'Pale One' 1"
@@ -25,6 +26,7 @@
 #newpose
 #name "atlantian thrall"
 #role "infantry"
+#subrace "Atlantian"
 
 #basechance 0
 #chanceinc "secondaryrace atlantian 1"
@@ -48,6 +50,7 @@
 #newpose
 #name "caelian thrall"
 #role "infantry"
+#subrace "Caelian"
 
 #basechance 0
 #chanceinc "secondaryrace 'caelian' 1"
@@ -73,6 +76,7 @@
 #newpose
 #name "hoburg thrall"
 #role "infantry"
+#subrace "hoburg"
 
 #basechance 0
 #chanceinc "secondaryrace 'hoburg' 1"
@@ -96,6 +100,7 @@
 #newpose
 #name "human thrall"
 #role "infantry"
+#subrace "human"
 
 #basechance 0
 #chanceinc "secondaryrace 'Advanced human' 1"
@@ -124,6 +129,7 @@
 #newpose
 #name "ichtyid thrall"
 #role "infantry"
+#subrace "ichtyid"
 
 #basechance 0
 #chanceinc "secondaryrace ichtyid 1"
@@ -147,6 +153,7 @@
 #newpose
 #name "lizard thrall"
 #role "infantry"
+#subrace "lizard"
 
 #basechance 0
 #chanceinc "secondaryrace 'lizard' 1"
@@ -171,6 +178,7 @@
 #newpose
 #name "muuch thrall"
 #role "infantry"
+#subrace "Atlantian"
 
 #basechance 0
 #chanceinc "secondaryrace muuch 1"
@@ -194,6 +202,7 @@
 #newpose
 #name "vanara thrall"
 #role "infantry"
+#subrace "vanara"
 
 #basechance 0
 #chanceinc "secondaryrace 'Primate' 1"


### PR DESCRIPTION
* Illithid have no subrace now (they're illithid, after all), but assorted lobo guards have assorted subraces
* Nephilim forced to subsist on a meager 120 people per month instead of their more-palatable serving size of 1200 in the current data