### PR TITLE
Sounder of Boars fix

### DIFF
--- a/data/spells/random_spells.txt
+++ b/data/spells/random_spells.txt
@@ -123,10 +123,12 @@
 #end
 
 -------- Nature
+
+-------- Sounder of Boars is specified by number to avoid the unresearchable combat summon effect earlier in the spell list
 #new
 #name "Boars"
 #spell "Monster Boar"
-#spell "Sounder of Boars"
+#spell "172"
 #basechance 0.5
 #chanceinc hasthemetheme boreal *2
 #chanceinc nationtag boreal *2


### PR DESCRIPTION
* Previously the lower-numbered unresearchable no-cost/no-fatigue/non-sacred-boars version of the spell (96) is selected instead of the Marverni sacred-boar ritual summon (172). Changing it to 172 makes random boreal/nature nations revere boars as sacred as a side effect, but it should solve the more pressing problem.
* Closes #830