### PR TITLE
Reduced/increased upkeep filters

### DIFF
--- a/data/filters/default_elitefilters.txt
+++ b/data/filters/default_elitefilters.txt
@@ -107,6 +107,23 @@
 #end
 
 #new
+#name "loyal-10"
+#basechance 0.25
+#chanceinc personalcommand gcost below 15 *0
+#chanceinc personalcommand gcost above 30 *0
+#command "#addupkeep -10"
+#command "#mor +1"
+#end
+
+#new
+#name "loyal-20"
+#basechance 0.25
+#chanceinc personalcommand gcost below 30 *0
+#command "#addupkeep -20"
+#command "#mor +1"
+#end
+
+#new
 #name "resistances"
 #basechance 0.0
 #chanceinc "magic air 0.1"

--- a/data/filters/default_magefilters.txt
+++ b/data/filters/default_magefilters.txt
@@ -1,4 +1,24 @@
 #new magefilter
+#name "highupkeep"
+#basechance 1
+#command "#addupkeep +50"
+#notfortier 1
+#power -1
+#theme upkeep
+#desc "Greedy"
+#end
+
+#new magefilter
+#name "lowupkeep"
+#basechance 1
+#command "#addupkeep -50"
+#notfortier 1
+#power 1
+#theme upkeep
+#desc "Altruistic"
+#end
+
+#new magefilter
 #name "poisonres"
 #basechance 0.1
 #command "#poisonres +5"

--- a/data/filters/default_sacredfilters.txt
+++ b/data/filters/default_sacredfilters.txt
@@ -1,3 +1,19 @@
+#new
+#name "ascetic-15"
+#basechance 0.25
+#chanceinc personalcommand gcost below 15 *0
+#chanceinc personalcommand gcost above 30 *0
+#command "#addupkeep -15"
+#command "#neednoteat"
+#end
+
+#new
+#name "ascetic-30"
+#basechance 0.125
+#chanceinc personalcommand gcost below 30 *0
+#command "#addupkeep -30"
+#command "#neednoteat"
+#end
 
 #new
 #name "reinvig 2"


### PR DESCRIPTION
Filters using the new #addupkeep command to directly manipulate effective costs for upkeep:
* Added T2/T3 power 1 filter that effectively reduces upkeep 40g/year (non-sacred)
* Added T2/T3 power -1 filter that effectively increases upkeep 40g/year (non-sacred)
* Added elite filter for gcost 15-30 elites that effectively reduces upkeep 8g/year and gives +1 mor
* Added elite filter for gcost 30+ elites that effectively reduces upkeep 16g/year and gives +1 mor
* Added sacred filter for gcost 15-30 elites that effectively reduces upkeep 6g/year and gives #neednoteat
* Added sacred filter for gcost 30+ elites that effectively reduces upkeep 12g/year and gives #neednoteat