### PR TITLE
Scaling mage upkeep filter

### DIFF
--- a/data/filters/default_magefilters.txt
+++ b/data/filters/default_magefilters.txt
@@ -1,8 +1,9 @@
 #new magefilter
 #name "highupkeep"
 #basechance 1
-#command "#addupkeep +50"
-#notfortier 1
+#command "#addupkeep +%value%"
+#basevalue 0
+#valuemulti 20
 #power -1
 #theme upkeep
 #desc "Greedy"
@@ -11,8 +12,9 @@
 #new magefilter
 #name "lowupkeep"
 #basechance 1
-#command "#addupkeep -50"
-#notfortier 1
+#command "#addupkeep -%value%"
+#basevalue 0
+#valuemulti 20
 #power 1
 #theme upkeep
 #desc "Altruistic"


### PR DESCRIPTION
* T1/T2/T3 get +/- 20/40/60gcost worth of upkeep (so +/-16/32/48g per year, or half that if sacred)
* As suggested in #839