### PR TITLE
Hoburg special commander filters

### DIFF
--- a/data/filters/filters.txt
+++ b/data/filters/filters.txt
@@ -21,3 +21,4 @@
 
 #load default_specialcommanderfilters ./data/filters/default_specialcommanderfilters.txt
 #load specialcommanderfilters_extended ./data/filters/specialcommanderfilters_extended.txt
+#load specialcommanderfilters_hoburg ./data/filters/specialcommanderfilters_hoburg.txt

--- a/data/filters/specialcommanderfilters_extended.txt
+++ b/data/filters/specialcommanderfilters_extended.txt
@@ -55,14 +55,13 @@
 #new
 #name "imp summoner"
 #command "#makemonsters1 303"
+#command "#poorundeadleader"
 #command "#gcost +30"
 #unitname "Imp Summoner"
 #basechance 0
 #chanceinc magic blood 0.5
 #caponlychance 1
 #description "is able to summon imps via ancient rituals."
-#theme "toadtotem"
-#theme "totemanimal"
 #pose role mage
 #themeinc theme cultist *10
 #themeinc thisitemtag "tier 1" *100
@@ -73,6 +72,7 @@
 #new
 #name "frog summoner"
 #command "#makemonsters2 2222"
+#command "#magiccommand 5"
 #command "#gcost +30"
 #unitname "Frogherd"
 #unitname "Frog Tamer"
@@ -185,6 +185,7 @@
 #new
 #name "ant summoner"
 #command "#makemonsters3 1087"
+#command "#magiccommand 5"
 #command "#gcost +30"
 #unitname "Antherd"
 #unitname "Ant Tamer"
@@ -209,6 +210,7 @@
 #new
 #name "fly summoner"
 #command "#makemonsters3 2218"
+#command "#magiccommand 5"
 #command "#gcost +30"
 #unitname "Lord of the Flies"
 #basechance 0.0
@@ -231,6 +233,7 @@
 #new
 #name "spider summoner"
 #command "#makemonsters3 2223"
+#command "#magiccommand 5"
 #command "#gcost +30"
 #unitname "Spiderbreeder"
 #unitname "Web Master"
@@ -256,6 +259,7 @@
 #new
 #name "scorpion summoner"
 #command "#makemonsters3 2232"
+#command "#magiccommand 5"
 #command "#gcost +30"
 #unitname "Scorpion Trainer"
 #unitname "Scorpion Master"

--- a/data/filters/specialcommanderfilters_hoburg.txt
+++ b/data/filters/specialcommanderfilters_hoburg.txt
@@ -1,0 +1,460 @@
+--- Usable special stuff that may be badly documented
+--
+-- #pose role/name <thing>
+-- Uses poses of <thing> name or role
+--
+-- #requiredposetag <tag>
+-- #requiredposetheme <theme>
+-- Excludes poses without this tag/theme
+--
+-- #equipmenttargettag <tag>
+-- Equipment will have to have this tag when it is available. 
+-- This is for "tier 1-3" for mage/priest type poses, but themeincs work well as well.
+--
+-- #troop
+-- This is a troop instead of commander (I'm looking at you, communion slave)
+--
+-- Extra tip: #generateitem works here like it should in all filters/equipment
+-- Extra tip: Special commanders get #poorleader or #noleader if nothing is specified
+
+#new
+#name "forager-troop-stealthy"
+#command "#supplybonus +6"
+#command "#pillagebonus +1"
+#command "#stealthy +0"
+#command "#gcost +6"
+#command "#reclimit 3"
+#caponlychance 0
+#unitname "Hunter"
+#unitname "Forager"
+#unitname "Poacher"
+#unitname "Raider"
+#unitname "Bushwacker"
+#unitname "Skulker"
+#unitname "Bandit"
+#basechance 0.5
+#description "is skilled at acquiring supplies by means both fair and foul."
+#pose role ranged
+#equipmenttargettag light
+#generateitem 1 cloakb
+#troop
+#end
+
+#new
+#name "forager-troop-mounted"
+#command "#supplybonus +8"
+#command "#pillagebonus +1"
+#command "#gcost +8"
+#command "#reclimit 3"
+#caponlychance 0
+#unitname "Hunter"
+#unitname "Forager"
+#unitname "Outrider"
+#unitname "Raider"
+#unitname "Bandit"
+#basechance 0.5
+#description "is skilled at acquiring supplies by means both fair and foul."
+#pose role mounted
+#equipmenttargettag light
+#generateitem 1 cloakb
+#troop
+#end
+
+#new
+#name "frog summoner"
+#command "#makemonsters2 2222"
+#command "#batstartsum1 2222"
+#command "#supplybonus +10"
+#command "#magiccommand 5"
+#command "#gcost +30"
+#unitname "Frogherd"
+#unitname "Frog Farmer"
+#basechance 0.05
+#chanceinc magic nature 0.5
+#caponlychance 0.9
+#description "raises frogs for food and war."
+#theme occidental
+#theme austral
+#theme oriental
+#theme boreal
+#theme central
+#theme "toadtotem"
+#theme "totemanimal"
+#pose role scout
+#themeinc theme herder *25
+#themeinc theme peasant *25
+#themeinc theme leather *10
+#themeinc thisarmorprot 12 *0.25
+#themeinc thisarmorprot 10 *0.25
+#possiblecommandset stealth 0.25
+#possiblecommand stealth "#stealthy +40"
+#possiblecommand stealth "#gcost +20"
+#end
+
+#new
+#name "wolfherd"
+#command "#makemonsters1 284"
+#command "#batstartsum1 284"
+#command "#supplybonus +10"
+#command "#gcost +30"
+#unitname "Wolfherd"
+#unitname "Wolf Trainer"
+#basechance 0.1
+#chanceinc magic nature 0.5
+#caponlychance 0.99
+#description "raises wolves for food and war."
+#theme occidental
+#theme austral
+#theme oriental
+#theme boreal
+#theme central
+#theme imperial
+#theme "wolftotem"
+#theme "totemanimal"
+#pose role scout
+#themeinc theme herder *25
+#themeinc theme peasant *25
+#themeinc theme leather *10
+#themeinc thisarmorprot 12 *0.25
+#themeinc thisarmorprot 10 *0.25
+#possiblecommandset stealth 0.25
+#possiblecommand stealth "#stealthy +40"
+#possiblecommand stealth "#gcost +20"
+#end
+
+#new
+#name "dogherd"
+#command "#makemonsters1 1560"
+#command "#batstartsum1 1560"
+#command "#supplybonus +10"
+#command "#gcost +30"
+#unitname "Houndsmaster"
+#unitname "Dog Trainer"
+#basechance 0.2
+#chanceinc magic nature 0.5
+#caponlychance 0.95
+#description "raises dogs for food and war."
+#theme occidental
+#theme austral
+#theme oriental
+#theme boreal
+#theme central
+#theme imperial
+#pose role scout
+#themeinc theme herder *25
+#themeinc theme peasant *25
+#themeinc theme leather *10
+#themeinc thisarmorprot 12 *0.25
+#themeinc thisarmorprot 10 *0.25
+#possiblecommandset stealth 0.25
+#possiblecommand stealth "#stealthy +40"
+#possiblecommand stealth "#gcost +20"
+#end
+
+#new
+#name "goatherd"
+#command "#makemonsters1 2227"
+#command "#batstartsum1 2227"
+#command "#supplybonus +15"
+#command "#gcost +30"
+#unitname "Shepherd"
+#unitname "Goatherd"
+#basechance 0.15
+#chanceinc magic nature 0.5
+#caponlychance 0.95
+#description "raises goats for food and war."
+#theme occidental
+#theme austral
+#theme oriental
+#theme boreal
+#theme central
+#theme imperial
+#pose role scout
+#themeinc theme herder *25
+#themeinc theme peasant *25
+#themeinc theme leather *10
+#themeinc thisarmorprot 12 *0.25
+#themeinc thisarmorprot 10 *0.25
+#possiblecommandset stealth 0.25
+#possiblecommand stealth "#stealthy +40"
+#possiblecommand stealth "#gcost +20"
+#end
+
+#new
+#name "swanherd"
+#command "#makemonsters1 2929"
+#command "#batstartsum1 2929"
+#command "#supplybonus +15"
+#command "#gcost +30"
+#unitname "Swanherd"
+#unitname "Swan Keeper"
+#basechance 0.05
+#chanceinc magic nature water 0.5
+#caponlychance 0.99
+#description "raises swans for food and war."
+#theme boreal
+#theme imperial
+#theme "fae"
+#theme "swantotem"
+#theme "birdtotem"
+#theme "totemanimal"
+#pose role scout
+#themeinc theme herder *25
+#themeinc theme peasant *25
+#themeinc theme leather *10
+#themeinc thisarmorprot 12 *0.25
+#themeinc thisarmorprot 10 *0.25
+#possiblecommandset stealth 0.25
+#possiblecommand stealth "#stealthy +40"
+#possiblecommand stealth "#gcost +20"
+#end
+
+#new
+#name "falconer"
+#command "#makemonsters1 517"
+#command "#batstartsum1 517"
+#command "#supplybonus +5"
+#command "#gcost +30"
+#unitname "Falconer"
+#unitname "Hawk Keeper"
+#unitname "Master of the Mews"
+#basechance 0.05
+#chanceinc magic air 0.5
+#caponlychance 0.99
+#description "raises hawks for food and war."
+#theme occidental
+#theme boreal
+#theme central
+#theme imperial
+#theme "hawktotem"
+#theme "birdtotem"
+#theme "totemanimal"
+#pose role scout
+#themeinc theme herder *25
+#themeinc theme peasant *25
+#themeinc theme leather *10
+#themeinc thisarmorprot 12 *0.25
+#themeinc thisarmorprot 10 *0.25
+#possiblecommandset stealth 0.25
+#possiblecommand stealth "#stealthy +40"
+#possiblecommand stealth "#gcost +20"
+#end
+
+#new
+#name "monkey breeder"
+#command "#makemonsters1 1116"
+#command "#batstartsum1 1116"
+#command "#supplybonus +15"
+#command "#gcost +30"
+#unitname "Monkey Breeder"
+#unitname "Monkey Trainer"
+#basechance 0.05
+#chanceinc magic nature 0.5
+#caponlychance 0.9
+#description "raises small monkeys for food and war."
+#theme occidental
+#theme austral
+#theme oriental
+#theme imperial
+#theme "monkeytotem"
+#theme "totemanimal"
+#pose role scout
+#themeinc theme herder *25
+#themeinc theme peasant *25
+#themeinc theme leather *10
+#themeinc thisarmorprot 12 *0.25
+#themeinc thisarmorprot 10 *0.25
+#possiblecommandset stealth 0.25
+#possiblecommand stealth "#stealthy +40"
+#possiblecommand stealth "#gcost +20"
+#end
+
+#new
+#name "ant summoner"
+#command "#makemonsters3 1087"
+#command "#batstartsum1 1087"
+#command "#supplybonus +10"
+#command "#magiccommand 5"
+#command "#gcost +30"
+#unitname "Antherd"
+#unitname "Ant Farmer"
+#basechance 0.0
+#chanceinc magic nature 0.125
+#caponlychance 0.8
+#description "raises large ants for food and war."
+#theme occidental
+#theme austral
+#theme oriental
+#theme boreal
+#theme central
+#theme imperial
+#theme abysian
+#theme "anttotem"
+#theme "totemanimal"
+#pose role scout
+#themeinc theme herder *25
+#themeinc theme peasant *25
+#themeinc theme leather *10
+#themeinc thisarmorprot 12 *0.25
+#themeinc thisarmorprot 10 *0.25
+#possiblecommandset stealth 0.25
+#possiblecommand stealth "#stealthy +40"
+#possiblecommand stealth "#gcost +20"
+#end
+
+#new
+#name "red ant summoner"
+#command "#makemonsters2 2224"
+#command "#batstartsum1 2224"
+#command "#supplybonus +15"
+#command "#magiccommand 5"
+#command "#gcost +30"
+#unitname "Antherd"
+#unitname "Ant Farmer"
+#basechance 0.0
+#chanceinc magic nature 0.125
+#chanceinc magic fire 0.125
+#caponlychance 0.8
+#description "raises enormous ants for food and war."
+#theme occidental
+#theme austral
+#theme abysian
+#theme "anttotem"
+#theme "totemanimal"
+#pose role scout
+#themeinc theme herder *25
+#themeinc theme peasant *25
+#themeinc theme leather *10
+#themeinc thisarmorprot 12 *0.25
+#themeinc thisarmorprot 10 *0.25
+#possiblecommandset stealth 0.25
+#possiblecommand stealth "#stealthy +40"
+#possiblecommand stealth "#gcost +20"
+#end
+
+#new
+#name "fly summoner"
+#command "#makemonsters3 2218"
+#command "#batstartsum1 2218"
+#command "#supplybonus +5"
+#command "#magiccommand 5"
+#command "#gcost +30"
+#unitname "Lord of the Flies"
+#unitname "Beetle Farmer"
+#unitname "Beetle Juicer"
+#basechance 0.0
+#chanceinc magic nature 0.125
+#chanceinc magic death 0.05
+#chanceinc magic nature death 1
+#caponlychance 0.8
+#description "raises enormous bugs for food and war."
+#theme occidental
+#theme austral
+#theme central
+#theme abysian
+#pose role scout
+#themeinc theme herder *25
+#themeinc theme peasant *25
+#themeinc theme leather *10
+#themeinc thisarmorprot 12 *0.25
+#themeinc thisarmorprot 10 *0.25
+#possiblecommandset stealth 0.25
+#possiblecommand stealth "#stealthy +40"
+#possiblecommand stealth "#gcost +20"
+#end
+
+#new
+#name "dragonfly summoner"
+#command "#makemonsters3 591"
+#command "#batstartsum1 591"
+#command "#supplybonus +5"
+#command "#magiccommand 5"
+#command "#gcost +30"
+#unitname "Lord of the Dragonflies"
+#unitname "Dragonfly Keeper"
+#basechance 0.0
+#chanceinc magic nature 0.5
+#caponlychance 0.8
+#description "raises enormous dragonflies for food and war."
+#theme occidental
+#theme austral
+#theme oriental
+#theme boreal
+#theme central
+#theme imperial
+#theme fae
+#pose role scout
+#themeinc theme herder *25
+#themeinc theme peasant *25
+#themeinc theme leather *10
+#themeinc thisarmorprot 12 *0.25
+#themeinc thisarmorprot 10 *0.25
+#possiblecommandset stealth 0.25
+#possiblecommand stealth "#stealthy +40"
+#possiblecommand stealth "#gcost +20"
+#end
+
+#new
+#name "spider summoner"
+#command "#makemonsters3 2223"
+#command "#batstartsum1 2223"
+#command "#supplybonus +10"
+#command "#magiccommand 5"
+#command "#gcost +30"
+#unitname "Spiderbreeder"
+#unitname "Web Master"
+#unitname "Lord of Spiders"
+#basechance 0.0
+#chanceinc magic nature 0.125
+#chanceinc "command #poisonres 0.075"
+#caponlychance 0.9
+#description "raises large spiders for food and war."
+#theme occidental
+#theme austral
+#theme "spidertotem"
+#theme "totemanimal"
+#pose role scout
+#themeinc theme herder *25
+#themeinc theme peasant *25
+#themeinc theme leather *10
+#themeinc thisarmorprot 12 *0.25
+#themeinc thisarmorprot 10 *0.25
+#possiblecommandset stealth 0.25
+#possiblecommand stealth "#stealthy +40"
+#possiblecommand stealth "#gcost +20"
+#end
+
+#new
+#name "scorpion summoner"
+#command "#makemonsters3 2232"
+#command "#batstartsum1 2232"
+#command "#supplybonus +5"
+#command "#magiccommand 5"
+#command "#gcost +30"
+#unitname "Scorpion Trainer"
+#unitname "Scorpion Master"
+#unitname "Scorpionherd"
+#basechance 0.0
+#chanceinc magic earth 0.125
+#chanceinc magic death 0.05
+#chanceinc magic fire 0.05
+#chanceinc magic earth death 0.5
+#chanceinc magic earth fire 0.5
+#chanceinc "command #poisonres 0.075"
+#caponlychance 0.99
+#description "raises oversized scorpions for food and war."
+#theme occidental
+#theme austral
+#theme abysian
+#theme "scorpiontotem"
+#theme "totemanimal"
+#pose role scout
+#themeinc theme herder *25
+#themeinc theme peasant *25
+#themeinc theme leather *10
+#themeinc thisarmorprot 12 *0.25
+#themeinc thisarmorprot 10 *0.25
+#possiblecommandset stealth 0.25
+#possiblecommand stealth "#stealthy +40"
+#possiblecommand stealth "#gcost +20"
+#end

--- a/data/items/hoburg/crossbow/armor.txt
+++ b/data/items/hoburg/crossbow/armor.txt
@@ -13,6 +13,7 @@
 #theme "occidental"
 #theme "abysian"
 #needs shirt noshirt
+#light
 #enditem
 
 
@@ -29,6 +30,7 @@
 #theme "austral"
 #theme "occidental"
 #needs shirt noshirt
+#light
 #enditem
 
 
@@ -45,6 +47,7 @@
 #theme "central"
 #theme "imperial"
 #theme "occidental"
+#light
 #enditem
 
 #newitem
@@ -57,6 +60,7 @@
 #theme "boreal"
 #theme "central"
 #theme "occidental"
+#light
 #enditem
 
 #newitem -- full leather, TODO: legs
@@ -70,6 +74,7 @@
 #theme "boreal"
 #theme "central"
 #needs legs leatherpants
+#light
 #enditem
 
 #newitem
@@ -79,6 +84,7 @@
 #armor
 #theme "leather"
 #theme "imperial"
+#light
 #enditem
 
 #newitem -- full leather
@@ -90,6 +96,7 @@
 #theme "leather"
 #theme "imperial"
 #needs legs leatherpants
+#light
 #enditem
 
 #newitem
@@ -101,6 +108,7 @@
 #theme "leather"
 #theme "occidental"
 #needstype legs warpants
+#light
 #enditem
 
 
@@ -116,6 +124,7 @@
 #theme "central"
 #theme "imperial"
 #theme "abysian"
+#light
 #enditem
 
 #newitem
@@ -126,6 +135,7 @@
 #theme "leather"
 #theme "boreal"
 #theme "central"
+#light
 #enditem
 
 #newitem -- full ring, TODO legs
@@ -136,6 +146,7 @@
 #theme "leather"
 #theme "boreal"
 #theme "central"
+#light
 #enditem
 
 #newitem
@@ -146,6 +157,7 @@
 #theme "leather"
 #theme "imperial"
 #theme "abysian"
+#light
 #enditem
 
 #newitem -- full ring
@@ -157,6 +169,7 @@
 #theme "imperial"
 #theme "abysian"
 #needs legs ringpants
+#light
 #enditem
 
 
@@ -170,6 +183,7 @@
 #theme "bronze"
 #theme "boreal"
 #theme "central"
+#light
 #enditem
 
 #newitem
@@ -201,6 +215,7 @@
 #armor
 #theme "bronze"
 #theme "occidental"
+#light
 #enditem
 
 #newitem
@@ -235,6 +250,7 @@
 #armor
 #theme "bronze"
 #theme "abysian"
+#light
 #enditem
 
 #newitem
@@ -280,6 +296,7 @@
 #theme "austral"
 #theme "boreal"
 #theme "central"
+#light
 #enditem
 
 #newitem
@@ -314,6 +331,7 @@
 #armor
 #theme "iron"
 #theme "abysian"
+#light
 #enditem
 
 #newitem

--- a/data/items/hoburg/crossbow/armor_oriental.txt
+++ b/data/items/hoburg/crossbow/armor_oriental.txt
@@ -11,6 +11,7 @@
 #armor
 #theme "leather"
 #theme "oriental"
+#light
 #enditem
 
 #newitem
@@ -23,6 +24,7 @@
 #armor
 #theme "leather"
 #theme "oriental"
+#light
 #enditem
 
 
@@ -37,6 +39,7 @@
 #needs legs ashigarupants
 #armor
 #theme "oriental"
+#light
 #enditem
 
 --- Samurai

--- a/data/items/hoburg/crossbow/armor_oriental_light.txt
+++ b/data/items/hoburg/crossbow/armor_oriental_light.txt
@@ -9,6 +9,7 @@
 #theme "naked"
 #theme "oriental"
 #needs shirt noshirt
+#light
 #enditem
 
 
@@ -24,6 +25,7 @@
 #armor
 #theme "leather"
 #theme "oriental"
+#light
 #enditem
 
 #newitem
@@ -36,6 +38,7 @@
 #armor
 #theme "leather"
 #theme "oriental"
+#light
 #enditem
 
 
@@ -50,4 +53,5 @@
 #needs legs ashigarupants
 #armor
 #theme "oriental"
+#light
 #enditem

--- a/data/items/hoburg/crossbow/bows.txt
+++ b/data/items/hoburg/crossbow/bows.txt
@@ -8,6 +8,7 @@
 #theme "central"
 #theme "imperial"
 #theme "oriental"
+#light
 #enditem
 
 #newitem
@@ -20,6 +21,7 @@
 #theme "central"
 #theme "imperial"
 #theme "oriental"
+#light
 #enditem
 
 #newitem
@@ -45,6 +47,7 @@
 #theme "wood"
 #theme "occidental"
 #theme "abysian"
+#light
 #enditem
 
 #newitem
@@ -55,6 +58,7 @@
 #theme "wood"
 #theme "occidental"
 #theme "abysian"
+#light
 #enditem
 
 #newitem
@@ -68,6 +72,7 @@
 #theme "central"
 #theme "occidental"
 #theme "oriental"
+#light
 #enditem
 
 #newitem
@@ -78,6 +83,7 @@
 #offsety -35
 #basechance 0.5
 #theme "occidental"
+#light
 #enditem
 
 #newitem
@@ -102,6 +108,7 @@
 #theme "imperial"
 #theme "occidental"
 #theme "abysian"
+#light
 #enditem
 
 #newitem

--- a/data/items/hoburg/crossbow/weapon.txt
+++ b/data/items/hoburg/crossbow/weapon.txt
@@ -11,6 +11,7 @@
 #theme "imperial"
 #theme "oriental"
 #theme "abysian"
+#light
 #enditem
 
 #newitem
@@ -57,6 +58,7 @@
 #theme "central"
 #theme "imperial"
 #theme "oriental"
+#light
 #enditem
 
 #newitem
@@ -68,6 +70,7 @@
 #theme "central"
 #theme "imperial"
 #theme "oriental"
+#light
 #enditem
 
 #newitem
@@ -77,6 +80,7 @@
 #theme "advanced"
 #theme "wood"
 #theme "occidental"
+#light
 #enditem
 
 #newitem
@@ -86,6 +90,7 @@
 #theme "advanced"
 #theme "wood"
 #theme "occidental"
+#light
 #enditem
 
 #newitem
@@ -100,6 +105,7 @@
 #theme "central"
 #theme "occidental"
 #theme "oriental"
+#light
 #enditem
 
 #newitem
@@ -112,6 +118,7 @@
 #theme "central"
 #theme "imperial"
 #theme "occidental"
+#light
 #enditem
 
 #newitem

--- a/data/items/hoburg/mounted/armor.txt
+++ b/data/items/hoburg/mounted/armor.txt
@@ -13,6 +13,7 @@
 #theme "occidental"
 #theme "abysian"
 #needs shirt noshirt
+#light
 #enditem
 
 
@@ -29,6 +30,7 @@
 #theme "austral"
 #theme "occidental"
 #needs shirt noshirt
+#light
 #enditem
 
 
@@ -45,6 +47,7 @@
 #theme "central"
 #theme "imperial"
 #theme "occidental"
+#light
 #enditem
 
 #newitem
@@ -57,6 +60,7 @@
 #theme "boreal"
 #theme "central"
 #theme "occidental"
+#light
 #enditem
 
 #newitem -- full leather
@@ -70,6 +74,7 @@
 #theme "boreal"
 #theme "central"
 #needs legs leatherpants
+#light
 #enditem
 
 #newitem
@@ -80,6 +85,7 @@
 #theme "leather"
 #theme "imperial"
 #theme "abysian"
+#light
 #enditem
 
 #newitem -- full leather
@@ -92,6 +98,7 @@
 #theme "imperial"
 #theme "abysian"
 #needs legs leatherpants
+#light
 #enditem
 
 #newitem
@@ -103,6 +110,7 @@
 #theme "leather"
 #theme "occidental"
 #needstype legs warpants
+#light
 #enditem
 
 --- Ring
@@ -117,6 +125,7 @@
 #theme "central"
 #theme "imperial"
 #theme "abysian"
+#light
 #enditem
 
 #newitem
@@ -127,6 +136,7 @@
 #theme "leather"
 #theme "boreal"
 #theme "central"
+#light
 #enditem
 
 #newitem -- full ring
@@ -138,6 +148,7 @@
 #theme "boreal"
 #theme "central"
 #needs legs ringpants
+#light
 #enditem
 
 #newitem
@@ -148,6 +159,7 @@
 #theme "leather"
 #theme "imperial"
 #theme "abysian"
+#light
 #enditem
 
 #newitem -- full ring
@@ -159,6 +171,7 @@
 #theme "imperial"
 #theme "abysian"
 #needs legs ringpants
+#light
 #enditem
 
 
@@ -172,6 +185,7 @@
 #theme "bronze"
 #theme "boreal"
 #theme "central"
+#light
 #enditem
 
 #newitem
@@ -203,6 +217,7 @@
 #armor
 #theme "bronze"
 #theme "occidental"
+#light
 #enditem
 
 #newitem
@@ -235,6 +250,7 @@
 #armor
 #theme "bronze"
 #theme "abysian"
+#light
 #enditem
 
 #newitem
@@ -279,6 +295,7 @@
 #theme "austral"
 #theme "boreal"
 #theme "central"
+#light
 #enditem
 
 #newitem
@@ -312,6 +329,7 @@
 #armor
 #theme "iron"
 #theme "abysian"
+#light
 #enditem
 
 #newitem

--- a/data/items/hoburg/mounted/armor_light.txt
+++ b/data/items/hoburg/mounted/armor_light.txt
@@ -13,6 +13,7 @@
 #theme "occidental"
 #theme "abysian"
 #needs shirt noshirt
+#light
 #enditem
 
 
@@ -29,6 +30,7 @@
 #theme "austral"
 #theme "occidental"
 #needs shirt noshirt
+#light
 #enditem
 
 
@@ -46,6 +48,7 @@
 #theme "central"
 #theme "imperial"
 #theme "occidental"
+#light
 #enditem
 
 #newitem
@@ -58,6 +61,7 @@
 #theme "boreal"
 #theme "central"
 #theme "occidental"
+#light
 #enditem
 
 #newitem -- full leather
@@ -71,6 +75,7 @@
 #theme "boreal"
 #theme "central"
 #needs legs leatherpants
+#light
 #enditem
 
 #newitem
@@ -80,6 +85,7 @@
 #armor
 #theme "leather"
 #theme "imperial"
+#light
 #enditem
 
 #newitem -- full leather
@@ -91,6 +97,7 @@
 #theme "leather"
 #theme "imperial"
 #needs legs leatherpants
+#light
 #enditem
 
 #newitem
@@ -102,6 +109,7 @@
 #theme "leather"
 #theme "occidental"
 #needstype legs warpants
+#light
 #enditem
 
 
@@ -117,6 +125,7 @@
 #theme "central"
 #theme "imperial"
 #theme "abysian"
+#light
 #enditem
 
 #newitem
@@ -127,6 +136,7 @@
 #theme "leather"
 #theme "boreal"
 #theme "central"
+#light
 #enditem
 
 #newitem -- full ring
@@ -138,6 +148,7 @@
 #theme "boreal"
 #theme "central"
 #needs legs ringpants
+#light
 #enditem
 
 #newitem
@@ -148,6 +159,7 @@
 #theme "leather"
 #theme "imperial"
 #theme "abysian"
+#light
 #enditem
 
 #newitem -- full ring
@@ -159,6 +171,7 @@
 #theme "imperial"
 #theme "abysian"
 #needs legs ringpants
+#light
 #enditem
 
 
@@ -172,6 +185,7 @@
 #theme "bronze"
 #theme "boreal"
 #theme "central"
+#light
 #enditem
 
 #newitem
@@ -205,6 +219,7 @@
 #armor
 #theme "bronze"
 #theme "occidental"
+#light
 #enditem
 
 #newitem
@@ -239,6 +254,7 @@
 #armor
 #theme "bronze"
 #theme "abysian"
+#light
 #enditem
 
 #newitem
@@ -285,6 +301,7 @@
 #theme "austral"
 #theme "boreal"
 #theme "central"
+#light
 #enditem
 
 #newitem
@@ -320,6 +337,7 @@
 #armor
 #theme "iron"
 #theme "abysian"
+#light
 #enditem
 
 #newitem

--- a/data/items/hoburg/mounted/cavalryweapons.txt
+++ b/data/items/hoburg/mounted/cavalryweapons.txt
@@ -39,6 +39,7 @@
 #theme "imperial"
 #theme "occidental"
 #theme "abysian"
+#light
 #enditem
 
 #newitem
@@ -51,6 +52,7 @@
 #theme "austral"
 #theme "central"
 #theme "imperial"
+#light
 #enditem
 
 #newitem
@@ -65,6 +67,7 @@
 #theme "central"
 #theme "imperial"
 #theme "abysian"
+#light
 #enditem
 
 #newitem
@@ -97,6 +100,7 @@
 #basechance 2
 #sprite /graphics/hoburg/weapon/clubsword.png
 #theme "occidental"
+#light
 #enditem
 
 #newitem
@@ -108,6 +112,7 @@
 #theme "bronze"
 #theme "austral"
 #theme "central"
+#light
 #enditem
 
 #newitem
@@ -142,6 +147,7 @@
 #theme "austral"
 #theme "central"
 #theme "occidental"
+#light
 #enditem
 
 #newitem
@@ -154,6 +160,7 @@
 #theme "boreal"
 #theme "abysian"
 #theme "central"
+#light
 #enditem
 
 #newitem
@@ -182,6 +189,7 @@
 #tag "notepic"
 #tag "maxprot 9"
 #lightlance
+#light
 #enditem
 
 #newitem

--- a/data/items/hoburg/mounted/cavalryweapons_oriental.txt
+++ b/data/items/hoburg/mounted/cavalryweapons_oriental.txt
@@ -8,6 +8,7 @@
 #tag "maxprot 9"
 #tag "notepic"
 #lightlance
+#light
 #enditem
 
 #newitem
@@ -53,6 +54,7 @@
 #gameid 377
 #sprite /graphics/hoburg/weapon/wakizasi.png
 #theme "iron"
+#light
 #enditem
 
 #newitem

--- a/data/items/hoburg/mounted/mounts.txt
+++ b/data/items/hoburg/mounted/mounts.txt
@@ -26,6 +26,7 @@
 #theme "imperial"
 #theme "occidental"
 #theme "oriental"
+#light
 #enditem
 
 #newitem
@@ -48,6 +49,7 @@
 #offsety -12
 #offsetx 1
 #theme "abysian"
+#light
 #enditem
 
 #newitem
@@ -77,6 +79,7 @@
 #theme "central"
 #theme "imperial"
 #theme "oriental"
+#light
 #enditem
 
 #newitem
@@ -102,6 +105,7 @@
 #offsetx 0
 #basechance 0.5
 #theme "abysian"
+#light
 #enditem
 
 #newitem
@@ -132,6 +136,7 @@
 #theme "parrot"
 #theme "parrottotem"
 #theme "totemanimal"
+#light
 #enditem
 
 #newitem
@@ -163,6 +168,7 @@
 #theme "parrot"
 #theme "parrottotem"
 #theme "totemanimal"
+#light
 #enditem
 
 #newitem
@@ -194,6 +200,7 @@
 #theme "parrot"
 #theme "parrottotem"
 #theme "totemanimal"
+#light
 #enditem
 
 #newitem
@@ -226,6 +233,7 @@
 #theme "parrot"
 #theme "parrottotem"
 #theme "totemanimal"
+#light
 #enditem
 
 #newitem
@@ -449,6 +457,7 @@
 #theme "imperial"
 #theme "oriental"
 #theme "abysian"
+#light
 #enditem
 
 #newitem

--- a/data/items/hoburg/mounted/shields.txt
+++ b/data/items/hoburg/mounted/shields.txt
@@ -23,6 +23,7 @@
 #theme "central"
 #theme "imperial"
 #theme "occidental"
+#light
 #enditem
 
 #newitem

--- a/data/items/hoburg/mounted/stealthymounts.txt
+++ b/data/items/hoburg/mounted/stealthymounts.txt
@@ -31,6 +31,7 @@
 #theme "occidental"
 #theme "oriental"
 #theme "abysian"
+#light
 #enditem
 
 #newitem
@@ -65,6 +66,7 @@
 #theme "imperial"
 #theme "occidental"
 #theme "oriental"
+#light
 #enditem
 
 #newitem
@@ -169,6 +171,7 @@
 #theme "imperial"
 #theme "occidental"
 #theme "oriental"
+#light
 #enditem
 
 #newitem
@@ -285,6 +288,7 @@
 #theme "imperial"
 #theme "occidental"
 #theme "oriental"
+#light
 #enditem
 
 #newitem
@@ -338,6 +342,7 @@
 #description "If the rider dies, the ant will carry on fighting until the end of the battle."
 #offsetx 1
 #offsety -4
+#light
 #enditem
 
 #newitem
@@ -377,6 +382,7 @@
 #tag "animal swan"
 #offsetx 0
 #offsety -4
+#light
 #enditem
 
 #newitem
@@ -408,6 +414,7 @@
 #basechance 1
 #offsetx 0
 #offsety -4
+#light
 #enditem
 
 #newitem
@@ -441,6 +448,7 @@
 #basechance 1
 #offsetx 4
 #offsety -13
+#light
 #enditem
 
 #newitem

--- a/data/items/hoburg/normal/helmet.txt
+++ b/data/items/hoburg/normal/helmet.txt
@@ -30,6 +30,7 @@
 #theme "iron"
 #theme "abysian"
 #theme "imperial"
+#light
 #enditem
 
 #newitem
@@ -42,6 +43,7 @@
 #theme "iron"
 #theme "abysian"
 #theme "imperial"
+#light
 #enditem
 
 #newitem
@@ -53,6 +55,7 @@
 #theme "leather"
 #theme "abysian"
 #theme "imperial"
+#light
 #enditem
 
 #newitem
@@ -62,6 +65,7 @@
 #tag "eliteversion leatherhat-elite"
 #armor
 #theme "leather"
+#light
 #enditem
 
 
@@ -97,6 +101,7 @@
 #armor
 #theme "elite"
 #theme "iron"
+#light
 #enditem
 
 
@@ -108,6 +113,7 @@
 #armor
 #theme "elite"
 #theme "leather"
+#light
 #enditem
 
 #newitem
@@ -118,6 +124,7 @@
 #armor
 #theme "elite"
 #theme "leather"
+#light
 #enditem
 
 
@@ -159,6 +166,7 @@
 #theme "iron"
 #theme "abysian"
 #theme "imperial"
+#light
 #enditem
 
 #newitem
@@ -171,6 +179,7 @@
 #theme "leather"
 #theme "abysian"
 #theme "imperial"
+#light
 #enditem
 
 #newitem
@@ -184,6 +193,7 @@
 #theme "leather"
 #theme "advanced"
 #theme "boreal"
+#light
 #enditem
 
 #newitem
@@ -197,6 +207,7 @@
 #theme "leather"
 #theme "advanced"
 #theme "boreal"
+#light
 #enditem
 
 #newitem
@@ -223,6 +234,7 @@
 #sprite /graphics/hoburg/helmet/bronzecap_cone.png
 #armor
 #theme "bronze"
+#light
 #enditem
 
 #newitem
@@ -233,6 +245,7 @@
 #eliteversion bronzecap_elite
 #armor
 #theme "bronze"
+#light
 #enditem
 
 #newitem
@@ -243,6 +256,7 @@
 #armor
 #theme "elite"
 #theme "bronze"
+#light
 #enditem
 
 #newitem
@@ -255,6 +269,7 @@
 #theme "bronze"
 #theme "austral"
 #theme "occidental"
+#light
 #enditem
 
 #newitem
@@ -268,6 +283,7 @@
 #theme "bronze"
 #theme "austral"
 #theme "occidental"
+#light
 #enditem
 
 #newitem
@@ -403,6 +419,7 @@
 #theme "central"
 #theme "austral"
 #theme "imperial"
+#light
 #enditem
 
 #newitem
@@ -417,6 +434,7 @@
 #theme "austral"
 #theme "imperial"
 #theme "elite"
+#light
 #enditem
 
 #newitem
@@ -429,6 +447,7 @@
 #armor
 #theme "leather"
 #theme "occidental"
+#light
 #enditem
 
 #newitem
@@ -444,6 +463,7 @@
 #theme "leather"
 #theme "austral"
 #theme "occidental"
+#light
 #enditem
 
 #newitem
@@ -458,6 +478,7 @@
 #theme "leather"
 #theme "austral"
 #theme "occidental"
+#light
 #enditem
 
 #newitem
@@ -474,6 +495,7 @@
 #theme "elite"
 #theme "austral"
 #theme "occidental"
+#light
 #enditem
 
 #newitem
@@ -487,6 +509,7 @@
 #theme "leather"
 #theme "austral"
 #theme "occidental"
+#light
 #enditem
 
 #newitem
@@ -501,6 +524,7 @@
 #theme "leather"
 #theme "austral"
 #theme "occidental"
+#light
 #enditem
 
 #newitem
@@ -514,6 +538,7 @@
 #theme "elite"
 #theme "austral"
 #theme "occidental"
+#light
 #enditem
 
 #newitem
@@ -528,4 +553,5 @@
 #theme "elite"
 #theme "austral"
 #theme "occidental"
+#light
 #enditem

--- a/data/items/hoburg/normal/helmet_oriental.txt
+++ b/data/items/hoburg/normal/helmet_oriental.txt
@@ -5,6 +5,7 @@
 #sprite /graphics/hoburg/helmet/topknot.png
 #armor
 #theme "naked"
+#light
 #enditem
 
 #newitem
@@ -14,6 +15,7 @@
 #tag "eliteversion leathercap-elite"
 #armor
 #theme "leather"
+#light
 #enditem
 
 #newitem
@@ -23,6 +25,7 @@
 #tag "eliteversion leatherhat-elite"
 #armor
 #theme "leather"
+#light
 #enditem
 
 #newitem
@@ -33,6 +36,7 @@
 #tag "eliteversion ironcap-elite"
 #armor
 #theme "iron"
+#light
 #enditem
 
 #newitem
@@ -43,6 +47,7 @@
 #tag "eliteversion ironcap-elite"
 #armor
 #theme "iron"
+#light
 #enditem
 
 #newitem
@@ -53,6 +58,7 @@
 #recolormask /graphics/hoburg/helmet/jingasa_recolormask.png
 #armor
 #theme "iron"
+#light
 #enditem
 
 #newitem

--- a/data/themes/hoburg_themes.txt
+++ b/data/themes/hoburg_themes.txt
@@ -35,6 +35,8 @@
 #racedefinition "#magicpriority nature 10"
 #racedefinition "#pose stealthyhoburgmages"
 #racedefinition "#pose stealthyhoburgtroops"
+#racedefinition "#specialcommanderchance 0.2"
+#racedefinition "#specialcommanderfilters specialcommanderfilters_hoburg"
 #racedefinition "#monsterchance 0.25"
 #racedefinition "#generationchance ranged 2"
 #racedefinition "#generationchance mounted 2"
@@ -65,6 +67,8 @@
 #racedefinition "#pose hoburgtroops"
 #racedefinition "#pose stealthyhoburgmages"
 #racedefinition "#pose stealthyhoburgtroops"
+#racedefinition "#specialcommanderchance 0.5"
+#racedefinition "#specialcommanderfilters specialcommanderfilters_hoburg"
 #racedefinition "#tag 'preferredmount hog'"
 #racedefinition "#theme 'primitive'"
 #endtheme
@@ -92,6 +96,8 @@
 #racedefinition "#pose clockworktroops"
 #racedefinition "#pose clockworktroops_oriental"
 #racedefinition "#pose clockworktroops_bronze"
+#racedefinition "#specialcommanderchance 0.1"
+#racedefinition "#specialcommanderfilters specialcommanderfilters_hoburg"
 #racedefinition "#theme 'advanced'"
 #endtheme
 


### PR DESCRIPTION
* Feral/agrarian hoburgs are slightly/much-more-likely to have special commanders; these will be either various chaff-summoners (a modified version of the extended filterset) or light-troops-as-special-commanders "forager/raiders"; in either case, these will grant supply bonuses (whether the summoner produces dogs, scorpions, or markatas; it's all meat...)
* Gave all special commanders with magicbeing or imp summoning a small amount of the associated command, even if right now it doesn't appear that specialcommanderfilters_extended is actually in use