### PR TITLE
Preview flag fix

### DIFF
--- a/src/nationGen/misc/PreviewGenerator.java
+++ b/src/nationGen/misc/PreviewGenerator.java
@@ -93,8 +93,7 @@ public class PreviewGenerator {
 			}
 		}
 	
-		FlagGen fg = new FlagGen(n);
-		BufferedImage flag = fg.generateFlag(n);
+		BufferedImage flag = n.flag;
 
 		g.setColor(new Color(0, 0, 0));
 		g.fillRect(0, 0, 256, 64);
@@ -130,7 +129,6 @@ public class PreviewGenerator {
 		
 		img = null;
 		g = null;
-		fg = null;
 		troops = null;
 	}
 	


### PR DESCRIPTION
Previously, like ages ago, flags were generated when writing the mod and thus there was separate flag generation using the same seed in preview and mod writing step. At some point flag generation was made sensible and flags were drawn during generation and stored, but previews were not changed. I'm not exactly sure what caused the bug, but it's probably relatively simple and fixing it by actually using the nation flag from the nation saves computing power so why not.

Closes #885