### PR TITLE
Small fixes

### DIFF
--- a/data/items/abysian/humanbred/mounts.txt
+++ b/data/items/abysian/humanbred/mounts.txt
@@ -6,8 +6,8 @@
 #gameid -1
 #sprite /graphics/abysian/mounts/scorpion.png
 #armor
-#offsetx 15
-#offsety 42
+#offsetx 23
+#offsety 6
 #define "#size 5"
 #define "#mapmove 2"
 #define "#ap 8"

--- a/data/monsters/hoburg_monsters.txt
+++ b/data/monsters/hoburg_monsters.txt
@@ -195,7 +195,6 @@
 #chanceinc "racetheme  occidental 1"
 #chanceinc "racetheme not feral *0"
 #chanceinc "racetheme  fae *0"
-#command "#copystats 2261"
 #command "#spr1 ./graphics/monsters/hoburg/giant_feral_boreal.png"
 #command "#spr2 shift"
 #command "#name 'Giant Hoburg'"


### PR DESCRIPTION
* Humanbred scorpion riders were using the old sprite size's offsets
* Boreal giant hoburgs had an errant copystats from war elephants in
their definition; the only thing it did was make them count as animals,
which was funny, but not intended