### PR TITLE
Custom Twiceborn shapes

### DIFF
--- a/data/items/abysian/bases.txt
+++ b/data/items/abysian/bases.txt
@@ -16,6 +16,7 @@
 #define "#fireres 25"
 #define "#darkvision 50"
 #define "#maxage 35"
+#define "#twiceborn 1978"
 #command "#descr 'The Abysians are a race of hellish humanoids with magma bodies. They radiate a furnace-like heat and are impervious to all forms of fire.'"
 #tag "noble"
 #enditem

--- a/data/items/abysian/burningone_bases.txt
+++ b/data/items/abysian/burningone_bases.txt
@@ -20,6 +20,7 @@
 #define "#speciallook 1"
 #define "#darkvision 50"
 #define "#maxage 35"
+#define "#twiceborn 1978"
 #command "#descr 'The Abysians are a race of hellish humanoids with magma bodies. Burning Ones are large Abysians in whom the Fires of Rhaux still burn brightly.'"
 #guaranteedprefix burning
 #tag "noble"

--- a/data/items/abysian/demonbred_bases.txt
+++ b/data/items/abysian/demonbred_bases.txt
@@ -22,6 +22,6 @@
 #define "#darkvision 100"
 #define "#maxage 250"
 #command "#descr 'Demonbred Abysians are the result of sinister crossbreeding experiments aiming to combine the traits of Abysians and demons. They are bound by their nature to serve their masters as willing slaves, and are both loyal and intelligent.'"
-#tag "noble"
 #tag "winged"
+#define "#twiceborn 1978"
 #enditem

--- a/data/items/abysian/humanbred/bases.txt
+++ b/data/items/abysian/humanbred/bases.txt
@@ -15,6 +15,7 @@
 #define "#ap 11"
 #define "#fireres 15"
 #define "#maxage 45"
+#define "#twiceborn 1978"
 #command "#descr 'Humanbred Abysians are the result of sinister crossbreeding experiments aiming to combine the best traits of the two races. They breed and grow quickly while sharing the Abysian resistance to heat; however, their flesh is far cooler than their hellish ancestors.'"
 #slow_militia
 #enditem

--- a/data/items/abysian/humanbred/warbred_bases.txt
+++ b/data/items/abysian/humanbred/warbred_bases.txt
@@ -16,6 +16,7 @@
 #define "#maxage 18"
 #define "#fireres 5"
 #define "#berserk +2"
+#define "#twiceborn 1978"
 #command "#descr 'Bred for strength and obedience, Warbred Abysians are the crown of the Abysian breeding experiments. The Warbred serve only one purpose, and have not been bred for longevity.'"
 #guaranteedprefix "warbred"
 #cannot_be_pd

--- a/data/items/agarthan/generic/bases.txt
+++ b/data/items/agarthan/generic/bases.txt
@@ -2,4 +2,5 @@
 #name "agarthan basesprite"
 #gameid -1
 #sprite /graphics/agarthan/basesprite.png
+#command "#twiceborn 1501"
 #enditem

--- a/data/items/agarthan/generic/rangedbases.txt
+++ b/data/items/agarthan/generic/rangedbases.txt
@@ -3,4 +3,5 @@
 #gameid -1
 #sprite /graphics/agarthan/basesprite.png
 #needs strap strap
+#command "#twiceborn 1501"
 #enditem

--- a/data/items/agarthan/generic_big/bases.txt
+++ b/data/items/agarthan/generic_big/bases.txt
@@ -15,5 +15,6 @@
 #define "#ap 14"
 #define "#siegebonus 5"
 #define "#startage 200"
+#define "#twiceborn 3189"
 #tag "noble"
 #enditem

--- a/data/items/agarthan/generic_big/bases_ageless.txt
+++ b/data/items/agarthan/generic_big/bases_ageless.txt
@@ -23,5 +23,6 @@
 #command "#maxage 800"
 #command "#siegebonus 25"
 #command "#holy"
+#define "#twiceborn 3189"
 #tag "noble"
 #enditem

--- a/data/items/agarthan/generic_big/bases_olmspawn.txt
+++ b/data/items/agarthan/generic_big/bases_olmspawn.txt
@@ -24,5 +24,6 @@
 #command "#maxage 1000"
 #command "#magiccommand +50"
 #command "#itemslots 13446"
+#define "#twiceborn 3189"
 
 #enditem

--- a/data/items/avvim/nephilim/bases.txt
+++ b/data/items/avvim/nephilim/bases.txt
@@ -27,5 +27,6 @@
 #command "#wastesurvival"
 #command "#nametype 140"
 #command "#heroarrivallimit 15"
+#command "#twiceborn 3179"
 #tag "noble"
 #enditem

--- a/data/items/avvim/normal/avvite_sacredbonusweapons.txt
+++ b/data/items/avvim/normal/avvite_sacredbonusweapons.txt
@@ -12,6 +12,7 @@
 #renderslot "cloakb"
 #description "Has wings and is thus able to fly"
 #tag "winged"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem

--- a/data/items/caelian/mage/wings-T1.txt
+++ b/data/items/caelian/mage/wings-T1.txt
@@ -17,6 +17,7 @@
 #define "#descr 'Caelians of the Spire Horn clan were blessed in ancient times by the Mainyus of wind and storms. They are often warriors and archers, and are little interested in magic.'"
 #tag "winged"
 #subraceprefix "spire horn"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -38,6 +39,7 @@
 #define "#descr 'Caelians of the Airya clan were blessed in ancient times by the Mainyus of the cold winter. They are of lighter stock than most Caelians and make poor fighters.'"
 #tag "winged"
 #subraceprefix "airya"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -61,6 +63,7 @@
 #define "#descr 'Caelians of the Raptor clan are stronger and more warlike than other Caelians. As their lineage descends from the wicked Daevas rather than the Yazatas, they have no particular tolerance for cold.'"
 #tag "winged"
 #subraceprefix "raptor"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -94,6 +97,7 @@
 #define "#descr 'Yazatas, or Adorable Ones, are semi-divine beings of an earlier age and the ancestors of most Caelians. Yazatas are attuned to air and are surrounded by an aura of splendor.'"
 #tag "winged"
 #subraceprefix "yazata"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -127,6 +131,7 @@
 #define "#descr 'Daevas are demonic beings of an earlier age and the ancestors of the Mairya and Raptor clans. Daevas are attuned to fire and are surrounded by an aura of fear.'"
 #tag "winged"
 #subraceprefix "daeva"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -151,6 +156,7 @@
 #define "#descr 'Caelians of the Mairya clan are the strongest and most warlike of all Caelians, in keeping with their Daevic ancestory. They have no particular tolerance for cold.'"
 #tag "winged"
 #subraceprefix "mairya"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -172,6 +178,7 @@
 #notfortier 2
 #notfortier 3
 #tag "winged"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem

--- a/data/items/caelian/mage/wings-T2.txt
+++ b/data/items/caelian/mage/wings-T2.txt
@@ -17,6 +17,7 @@
 #define "#descr 'Caelians of the Spire Horn clan were blessed in ancient times by the Mainyus of wind and storms. They are often warriors and archers, and are little interested in magic.'"
 #tag "winged"
 #subraceprefix "spire horn"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -38,6 +39,7 @@
 #define "#descr 'Caelians of the Airya clan were blessed in ancient times by the Mainyus of the cold winter. They are of lighter stock than most Caelians and make poor fighters.'"
 #tag "winged"
 #subraceprefix "airya"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -61,6 +63,7 @@
 #define "#descr 'Caelians of the Raptor clan are stronger and more warlike than other Caelians. As their lineage descends from the wicked Daevas rather than the Yazatas, they have no particular tolerance for cold.'"
 #tag "winged"
 #subraceprefix "raptor"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -94,6 +97,7 @@
 #define "#descr 'Yazatas, or Adorable Ones, are semi-divine beings of an earlier age and the ancestors of most Caelians. Yazatas are attuned to air and are surrounded by an aura of splendor.'"
 #tag "winged"
 #subraceprefix "yazata"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -127,6 +131,7 @@
 #define "#descr 'Daevas are demonic beings of an earlier age and the ancestors of the Mairya and Raptor clans. Daevas are attuned to fire and are surrounded by an aura of fear.'"
 #tag "winged"
 #subraceprefix "daeva"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -151,6 +156,7 @@
 #define "#descr 'Caelians of the Mairya clan are the strongest and most warlike of all Caelians, in keeping with their Daevic ancestory. They have no particular tolerance for cold.'"
 #tag "winged"
 #subraceprefix "mairya"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -172,6 +178,7 @@
 #tier 2
 #notfortier 3
 #tag "winged"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem

--- a/data/items/caelian/mage/wings-T3.txt
+++ b/data/items/caelian/mage/wings-T3.txt
@@ -17,6 +17,7 @@
 #define "#descr 'Caelians of the Spire Horn clan were blessed in ancient times by the Mainyus of wind and storms. They are often warriors and archers, and are little interested in magic.'"
 #tag "winged"
 #subraceprefix "spirehorn"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -38,6 +39,7 @@
 #define "#descr 'Caelians of the Airya clan were blessed in ancient times by the Mainyus of the cold winter. They are of lighter stock than most Caelians and make poor fighters.'"
 #tag "winged"
 #subraceprefix "airya"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -61,6 +63,7 @@
 #define "#descr 'Caelians of the Raptor clan are stronger and more warlike than other Caelians. As their lineage descends from the wicked Daevas rather than the Yazatas, they have no particular tolerance for cold.'"
 #tag "winged"
 #subraceprefix "raptor"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -94,6 +97,7 @@
 #define "#descr 'Yazatas, or Adorable Ones, are semi-divine beings of an earlier age and the ancestors of most Caelians. Yazatas are attuned to air and are surrounded by an aura of splendor.'"
 #tag "winged"
 #subraceprefix "yazata"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -127,6 +131,7 @@
 #define "#descr 'Daevas are demonic beings of an earlier age and the ancestors of the Mairya and Raptor clans. Daevas are attuned to fire and are surrounded by an aura of fear.'"
 #tag "winged"
 #subraceprefix "daeva"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -151,6 +156,7 @@
 #define "#descr 'Caelians of the Mairya clan are the strongest and most warlike of all Caelians, in keeping with their Daevic ancestory. They have no particular tolerance for cold.'"
 #tag "winged"
 #subraceprefix "mairya"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -172,6 +178,7 @@
 #notfortier 2
 #tier 3
 #tag "winged"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem

--- a/data/items/caelian/normal/wings.txt
+++ b/data/items/caelian/normal/wings.txt
@@ -16,6 +16,7 @@
 #define "#descr 'Caelians of the Spire Horn clan were blessed in ancient times by the Mainyus of wind and storms. They are often warriors and archers, and are little interested in magic.'"
 #tag "winged"
 #subraceprefix "spire horn"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -35,6 +36,7 @@
 #define "#descr 'Caelians of the Spire Horn clan were blessed in ancient times by the Mainyus of wind and storms. They are often warriors and archers, and are little interested in magic.'"
 #tag "winged"
 #subraceprefix "spire horn"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -53,6 +55,7 @@
 #define "#descr 'Caelians of the Airya clan were blessed in ancient times by the Mainyus of the cold winter. They are of lighter stock than most Caelians and make poor fighters.'"
 #tag "winged"
 #subraceprefix "airya"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -73,6 +76,7 @@
 #define "#descr 'Caelians of the Airya clan were blessed in ancient times by the Mainyus of the cold winter. They are of lighter stock than most Caelians and make poor fighters.'"
 #tag "winged"
 #subraceprefix "airya"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -93,6 +97,7 @@
 #define "#descr 'Caelians of the Raptor clan are stronger and more warlike than other Caelians. As their lineage descends from the wicked Daevas rather than the Yazatas, they have no particular tolerance for cold.'"
 #tag "winged"
 #subraceprefix "raptor"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -115,6 +120,7 @@
 #define "#descr 'Caelians of the Raptor clan are stronger and more warlike than other Caelians. As their lineage descends from the wicked Daevas rather than the Yazatas, they have no particular tolerance for cold.'"
 #tag "winged"
 #subraceprefix "raptor"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -137,6 +143,7 @@
 #define "#descr 'Caelians of the Mairya clan are the strongest and most warlike of all Caelians, in keeping with their Daevic ancestory. They have no particular tolerance for cold.'"
 #tag "winged"
 #subraceprefix "mairya"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -161,6 +168,7 @@
 #define "#descr 'Caelians of the Mairya clan are the strongest and most warlike of all Caelians, in keeping with their Daevic ancestory. They have no particular tolerance for cold.'"
 #tag "winged"
 #subraceprefix "mairya"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -179,6 +187,7 @@
 #define "#coldres +5"
 #define "#flying"
 #tag "winged"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -199,6 +208,7 @@
 #define "#coldres +5"
 #define "#flying"
 #tag "winged"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem

--- a/data/items/caelian/normal/wings_elite.txt
+++ b/data/items/caelian/normal/wings_elite.txt
@@ -16,6 +16,7 @@
 #subrace "Spire Horn"
 #tag "winged"
 #subraceprefix "spre horn"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -35,6 +36,7 @@
 #subrace "Airya"
 #tag "winged"
 #subraceprefix "airya"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -56,6 +58,7 @@
 #subrace "Raptor"
 #tag "winged"
 #subraceprefix "raptor"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -91,6 +94,7 @@
 #sacredcostmulti 1.2
 #sacredratingmulti 1.4
 #innate_sacred_power 2
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -128,6 +132,7 @@
 #sacredcostmulti 1.2
 #sacredratingmulti 1.4
 #innate_sacred_power 2
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -164,6 +169,7 @@
 #sacredcostmulti 1.2
 #sacredratingmulti 1.4
 #innate_sacred_power 2
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -202,6 +208,7 @@
 #sacredcostmulti 1.2
 #sacredratingmulti 1.4
 #innate_sacred_power 2
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -225,6 +232,7 @@
 #subrace "Mairya"
 #tag "winged"
 #subraceprefix "mairya"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -245,6 +253,7 @@
 #define "#coldres +5"
 #define "#flying"
 #tag "winged"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem

--- a/data/items/dynastichuman/bases_dynastic.txt
+++ b/data/items/dynastichuman/bases_dynastic.txt
@@ -23,6 +23,7 @@
 #define "#fireres 5"
 #define "#wastesurvival"
 #define "#nametype 113"
+#unitcommand "#twiceborn 1978"
 #subraceprefix "human"
 #slow_militia
 #enditem

--- a/data/items/dynastichuman/bases_dynastic_2h.txt
+++ b/data/items/dynastichuman/bases_dynastic_2h.txt
@@ -23,6 +23,7 @@
 #define "#fireres 5"
 #define "#wastesurvival"
 #define "#nametype 113"
+#unitcommand "#twiceborn 1978"
 #slow_militia
 #subraceprefix "human"
 #enditem

--- a/data/items/dynastichuman/bases_slave.txt
+++ b/data/items/dynastichuman/bases_slave.txt
@@ -28,6 +28,7 @@
 #define "#wastesurvival"
 #command "#slave"
 #define "#nametype 113"
+#unitcommand "#twiceborn 1978"
 #slow_militia
 #subraceprefix "human"
 #enditem
@@ -62,6 +63,7 @@
 #define "#wastesurvival"
 #command "#slave"
 #define "#nametype 113"
+#unitcommand "#twiceborn 1978"
 #slow_militia
 #subraceprefix "human"
 #enditem
@@ -96,6 +98,7 @@
 #define "#wastesurvival"
 #command "#slave"
 #define "#nametype 113"
+#unitcommand "#twiceborn 1978"
 #slow_militia
 #subraceprefix "human"
 #enditem

--- a/data/items/dynastichuman/bases_slave_2h.txt
+++ b/data/items/dynastichuman/bases_slave_2h.txt
@@ -24,6 +24,7 @@
 #define "#wastesurvival"
 #command "#slave"
 #define "#nametype 113"
+#unitcommand "#twiceborn 1978"
 #slow_militia
 #subraceprefix "human"
 #enditem
@@ -54,6 +55,7 @@
 #define "#wastesurvival"
 #command "#slave"
 #define "#nametype 113"
+#unitcommand "#twiceborn 1978"
 #slow_militia
 #subraceprefix "human"
 #enditem
@@ -84,6 +86,7 @@
 #define "#wastesurvival"
 #command "#slave"
 #define "#nametype 113"
+#unitcommand "#twiceborn 1978"
 #slow_militia
 #subraceprefix "human"
 #enditem

--- a/data/items/enlightened/dantih/sacredwings.txt
+++ b/data/items/enlightened/dantih/sacredwings.txt
@@ -16,4 +16,5 @@
 #description "Has wings and is thus able to fly"
 #basechance 0.05
 #tag "winged"
+#define "#twiceborn 3180"
 #enditem

--- a/data/items/enlightened/naga/bases.txt
+++ b/data/items/enlightened/naga/bases.txt
@@ -27,4 +27,5 @@
 #define "#weapon 141" -- Poison spit
 #define "#weapon 239" -- Venomous fangs
 #define "#itemslots 13446"
+#define "#twiceborn 3181"
 #enditem

--- a/data/items/enlightened/naga/bases_archers.txt
+++ b/data/items/enlightened/naga/bases_archers.txt
@@ -27,4 +27,5 @@
 #define "#weapon 141" -- Poison spit
 #define "#weapon 239" -- Venomous fangs
 #define "#itemslots 13446"
+#define "#twiceborn 3181"
 #enditem

--- a/data/items/enlightened/naga/bases_charioteers.txt
+++ b/data/items/enlightened/naga/bases_charioteers.txt
@@ -21,4 +21,5 @@
 #define "#weapon 595" -- Hypnotize
 #define "#weapon 141" -- Poison spit
 #define "#itemslots 13446"
+#define "#twiceborn 3181"
 #enditem

--- a/data/items/foulspawn/medium/bases.txt
+++ b/data/items/foulspawn/medium/bases.txt
@@ -18,6 +18,7 @@
 #command "#ap 4"
 #command "#maxage 50"
 #command "#coldres 5"
+#command "#twiceborn 3178"
 #enditem
 
 #newitem
@@ -39,6 +40,7 @@
 #command "#mapmove 4"
 #command "#ap 4"
 #command "#maxage 50"
+#command "#twiceborn 3196"
 #enditem
 
 #newitem
@@ -60,6 +62,7 @@
 #command "#mapmove 4"
 #command "#ap 5"
 #command "#maxage 50"
+#command "#twiceborn 3178"
 #enditem
 
 #newitem
@@ -81,6 +84,7 @@
 #command "#mapmove 4"
 #command "#ap 4"
 #command "#maxage 500"
+#command "#twiceborn 3178"
 #enditem
 
 #newitem
@@ -102,6 +106,7 @@
 #command "#mapmove 4"
 #command "#ap 4"
 #command "#maxage 500"
+#command "#twiceborn 3178"
 #enditem
 
 #newitem
@@ -125,4 +130,5 @@
 #command "#maxage 75"
 #command "#poisonres 10"
 #command "#coldblood"
+#command "#twiceborn 3178"
 #enditem

--- a/data/items/foulspawn/mounted/legs.txt
+++ b/data/items/foulspawn/mounted/legs.txt
@@ -35,6 +35,7 @@
 #define "#rcost +2"
 #define "#flying"
 #tag "animal goat"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -78,6 +79,7 @@
 #define "#weapon 55"
 #define "#flying"
 #tag "animal horse"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -213,6 +215,7 @@
 #define "#poisonres +5"
 #define "#gcost +15"
 #tag "animal worm"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -308,4 +311,5 @@
 #define "#flying"
 #tag "animal lizard"
 #define "#maxage *1.25"
+#define "#twiceborn 3180"
 #enditem

--- a/data/items/foulspawn/small/wings.txt
+++ b/data/items/foulspawn/small/wings.txt
@@ -9,6 +9,7 @@
 #define "#ressize 2"
 #define "#mapmove +6"
 #tag "winged"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -23,6 +24,7 @@
 #define "#ressize 2"
 #define "#mapmove +6"
 #tag "winged"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -38,6 +40,7 @@
 #define "#ressize 2"
 #define "#mapmove +6"
 #tag "winged"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -64,6 +67,7 @@
 #define "#mapmove +4"
 #command "#ap -2"
 #tag "winged"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem

--- a/data/items/halfmen/centaur/bases_centaur.txt
+++ b/data/items/halfmen/centaur/bases_centaur.txt
@@ -25,4 +25,5 @@
 #define "#itemslots 13446"
 #subrace "centaur"
 #subraceprefix centaur
+#command "#twiceborn 714"
 #enditem

--- a/data/items/halfmen/centaur/bases_centauride.txt
+++ b/data/items/halfmen/centaur/bases_centauride.txt
@@ -26,4 +26,5 @@
 #define "#itemslots 13446"
 #subrace "centauride"
 #subraceprefix centauride
+#command "#twiceborn 714"
 #enditem

--- a/data/items/halfmen/metis/bases_minocentaur.txt
+++ b/data/items/halfmen/metis/bases_minocentaur.txt
@@ -32,6 +32,7 @@
 #theme "savage"
 #theme "primitive"
 #subraceprefix minocentaur
+#command "#twiceborn 714"
 #enditem
 
 #newitem
@@ -67,6 +68,7 @@
 #theme "advanced"
 #theme "civilized"
 #subraceprefix minocentaur
+#command "#twiceborn 714"
 #enditem
 
 
@@ -104,6 +106,7 @@
 #theme "savage"
 #theme "primitive"
 #subraceprefix minocentaur
+#command "#twiceborn 714"
 #enditem
 
 #newitem
@@ -140,6 +143,7 @@
 #theme "advanced"
 #theme "civilized"
 #subraceprefix minocentaur
+#command "#twiceborn 714"
 #enditem
 
 #newitem
@@ -176,6 +180,7 @@
 #theme "savage"
 #theme "primitive"
 #subraceprefix minocentaur
+#command "#twiceborn 714"
 #enditem
 
 #newitem
@@ -211,4 +216,5 @@
 #theme "advanced"
 #theme "civilized"
 #subraceprefix minocentaur
+#command "#twiceborn 714"
 #enditem

--- a/data/items/halfmen/minotaur/2h_bases.txt
+++ b/data/items/halfmen/minotaur/2h_bases.txt
@@ -30,6 +30,7 @@
 #theme "primitive"
 #subrace minotaur
 #subraceprefix minotaur
+#command "#twiceborn 710"
 #enditem
 
 #newitem
@@ -63,4 +64,5 @@
 #theme "civilized"
 #subrace minotaur
 #subraceprefix minotaur
+#command "#twiceborn 710"
 #enditem

--- a/data/items/halfmen/minotaur/bases.txt
+++ b/data/items/halfmen/minotaur/bases.txt
@@ -31,6 +31,7 @@
 #theme "primitive"
 #subrace minotaur
 #subraceprefix minotaur
+#command "#twiceborn 710"
 #enditem
 
 #newitem
@@ -65,4 +66,5 @@
 #theme "civilized"
 #subrace minotaur
 #subraceprefix minotaur
+#command "#twiceborn 710"
 #enditem

--- a/data/items/halfmen/minotaur/bases_caster.txt
+++ b/data/items/halfmen/minotaur/bases_caster.txt
@@ -32,6 +32,7 @@
 #needstype hands brown
 #subrace minotaur
 #subraceprefix minotaur
+#command "#twiceborn 710"
 #enditem
 
 #newitem
@@ -68,6 +69,7 @@
 #needstype hands brown
 #subrace minotaur
 #subraceprefix minotaur
+#command "#twiceborn 710"
 #enditem
 
 #newitem
@@ -104,6 +106,7 @@
 #needstype hands white
 #subrace minotaur
 #subraceprefix minotaur
+#command "#twiceborn 710"
 #enditem
 
 #newitem
@@ -140,4 +143,5 @@
 #needstype hands black
 #subrace minotaur
 #subraceprefix minotaur
+#command "#twiceborn 710"
 #enditem

--- a/data/items/hoburg/normal/normal_sacredbonusweapons.txt
+++ b/data/items/hoburg/normal/normal_sacredbonusweapons.txt
@@ -20,4 +20,5 @@
 #description "Has wings and is thus able to fly"
 #basechance 0.25
 #tag "winged"
+#define "#twiceborn 3180"
 #enditem

--- a/data/items/human/sacredstuff/human_sacredbonusweapons.txt
+++ b/data/items/human/sacredstuff/human_sacredbonusweapons.txt
@@ -12,6 +12,7 @@
 #renderslot "cloakb"
 #description "Has wings and is thus able to fly"
 #tag "winged"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem

--- a/data/items/illithid/illithid/bases.txt
+++ b/data/items/illithid/illithid/bases.txt
@@ -2,4 +2,5 @@
 #name "illithid"
 #gameid -1
 #sprite /graphics/illithid/illithid/basesprite.png
+#command "#twiceborn 3195"
 #enditem

--- a/data/items/monkey/bandar/normal/wings.txt
+++ b/data/items/monkey/bandar/normal/wings.txt
@@ -14,6 +14,7 @@
 #gameid -1
 #sprite /graphics/monkey/bandar_wings.png
 #tag "winged"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -27,4 +28,5 @@
 #gameid -1
 #sprite /graphics/monkey/bandarbred_wings.png
 #tag "winged"
+#define "#twiceborn 3180"
 #enditem

--- a/data/items/monkey/colossi/wings.txt
+++ b/data/items/monkey/colossi/wings.txt
@@ -12,4 +12,5 @@
 #gameid -1
 #sprite /graphics/monkey/giant/wings.png
 #tag "winged"
+#define "#twiceborn 3180"
 #enditem

--- a/data/items/monkey/markata/wings.txt
+++ b/data/items/monkey/markata/wings.txt
@@ -14,4 +14,5 @@
 #nogen
 #sprite /graphics/monkey/markata_wings.png
 #tag "winged"
+#define "#twiceborn 3180"
 #enditem

--- a/data/items/monkey/vanara/mounted/wings.txt
+++ b/data/items/monkey/vanara/mounted/wings.txt
@@ -14,4 +14,5 @@
 #nogen
 #sprite /graphics/monkey/vanara_wings.png
 #tag "winged"
+#define "#twiceborn 3180"
 #enditem

--- a/data/items/monkey/vanara/normal/wings.txt
+++ b/data/items/monkey/vanara/normal/wings.txt
@@ -15,6 +15,7 @@
 #sprite /graphics/monkey/vanara_wings.png
 #needs overlay vanara_wings
 #tag "winged"
+#define "#twiceborn 3180"
 #enditem
 
 #newitem
@@ -30,4 +31,5 @@
 #gameid -1
 #sprite /graphics/monkey/vanarabred_wings.png
 #tag "winged"
+#define "#twiceborn 3180"
 #enditem

--- a/data/items/ogre/bases_ettinling.txt
+++ b/data/items/ogre/bases_ettinling.txt
@@ -30,4 +30,5 @@
 #baseitemslot misc 1
 #needs hands ettinling
 #undisciplined_militia
+#command "#twiceborn 3178"
 #enditem

--- a/data/items/ogre/bases_obakemono.txt
+++ b/data/items/ogre/bases_obakemono.txt
@@ -23,4 +23,5 @@
 #needs hands bakemono
 #poor_commander
 #undisciplined_militia
+#command "#twiceborn 3196"
 #enditem

--- a/data/items/ogre/bases_ogre.txt
+++ b/data/items/ogre/bases_ogre.txt
@@ -23,4 +23,5 @@
 #needs hands ogre
 #poor_commander
 #undisciplined_militia
+#command "#twiceborn 3178"
 #enditem

--- a/data/items/oriental/2h/bases.txt
+++ b/data/items/oriental/2h/bases.txt
@@ -5,4 +5,5 @@
 #needs overlay wings
 #tag "noble"
 #tag "winged"
+#define "#twiceborn 3180"
 #enditem

--- a/data/items/oriental/normal/bases.txt
+++ b/data/items/oriental/normal/bases.txt
@@ -5,4 +5,5 @@
 #needs overlay wings
 #tag "noble"
 #tag "winged"
+#define "#twiceborn 3180"
 #enditem

--- a/data/items/zotz/wings.txt
+++ b/data/items/zotz/wings.txt
@@ -3,4 +3,5 @@
 #gameid -1
 #sprite /graphics/zotz/wings.png
 #tag "winged"
+#define "#twiceborn 3180"
 #enditem

--- a/data/races/lizards.txt
+++ b/data/races/lizards.txt
@@ -40,6 +40,7 @@
 #unitcommand "#swampsurvival"
 #unitcommand "#coldblood"
 #unitcommand "#swimming"
+#unitcommand "#twiceborn 3180"
 #nationcommand "#idealcold -2"
 #tag "preferredmount serpent"
 #tag "preferredmount lizard"

--- a/data/races/serpentmen.txt
+++ b/data/races/serpentmen.txt
@@ -25,6 +25,7 @@
 #unitcommand "#nametype 113"
 #unitcommand "#maxage 75"
 #unitcommand "#itemslots 13446"
+#unitcommand "#twiceborn 3181"
 
 #magicpatterns defaultprimary
 #magicpatterns defaultsecondary

--- a/data/races/vaettir.txt
+++ b/data/races/vaettir.txt
@@ -38,6 +38,8 @@
 #unitcommand "#maxage 50"
 #unitcommand "#forestsurvival"
 -- Stealth is given on a per-pose basis as some mounted units aren't stealthy
+#unitcommand "#twiceborn 2190"
+-- Vaettir turn into draugs because it seems reasonable, mostly, even if the description is off
 
 #nationcommand "#idealcold +2"
 #gods europegods

--- a/data/races/vanir.txt
+++ b/data/races/vanir.txt
@@ -34,6 +34,7 @@
 #unitcommand "#illusion"
 #unitcommand "#stealthy 0"
 #unitcommand "#maxage 1000"
+#unitcommand "#twiceborn 2190"
 
 #innate_sacred_power 2
 


### PR DESCRIPTION
* Partially addresses #947
* Most fliers turn into id3180 unless something more appropriate is available
* Abysians and dynastic humans become Dust Priests (id1978)
* Little Pale Ones turn into Cavern Wights (id1501), big ones turn into Wight Oracles (id 3189)
* Nephilim (who should only be heroes) turn into Wight Murmurers (id3179)
* Lizards of all sorts become id3181, as do serpentmen and naga. The latter is weird, but they were gonna magically grow feet in any case, so...
* Ogres turn into Wight Shamans (id3178) unless they're o-bakemono, who become Wight Mages (id3196); Foulspawn with similar bodytypes to each do likewise
* Centaur-ish things become Carrion Centaurs (id714), while minotaurs become Carrion Lords (id710)
* Illithids become Atlantian-looking Wight Mages (id3195), which is weird, but it's what vanilla does and lets them stay full amphibian
* Vanir become draugs (id2190), as do vaettir (the latter mostly "because")

Some of these will result in odd descriptions, but since NG has plenty of weird descriptions right now I'm more concerned with gameplay than fluff.