### PR TITLE
PD number changes

### DIFF
--- a/settings.txt
+++ b/settings.txt
@@ -28,21 +28,21 @@ era 2
 -- 20 / (rescost + goldcost) * 10 * militiaMultiplier = amount of specified unit in militia
 militiaMultiplier 1.0
 
--- If resource is as treshold or above, change is applied
-resUpperTreshold 14
-resUpperTresholdChange -2
+-- If resource is as threshold or above, change is applied (but value will not be changed such that it would not have triggered the threshold)
+resUpperTreshold 10
+resUpperTresholdChange -6
 -- Same as above but for gold
-goldUpperTreshold 10
-goldUpperTresholdChange 0
+goldUpperTreshold 29
+goldUpperTresholdChange 10
 -- Above stuff but for lower bounds
-resLowerTreshold 10
-resLowerTresholdChange 0
-goldLowerTreshold 10
-goldLowerTresholdChange 0
+resLowerTreshold 6
+resLowerTresholdChange 3
+goldLowerTreshold 6
+goldLowerTresholdChange 3
 
--- Multiplies any resources above 10 by resMulti if rescost is at least at treshold
--- Done after the additive tresholds above.
-resMultiTreshold 10
+-- Multiplies any resources above threshold by resMulti if rescost is at least at threshold
+-- Done after the additive thresholds above.
+resMultiTreshold 16
 resMulti 0.7
 
 

--- a/src/nationGen/nation/PDSelector.java
+++ b/src/nationGen/nation/PDSelector.java
@@ -493,17 +493,26 @@ public class PDSelector {
 		int res = u.getResCost(true);
 		int gold = u.getGoldCost();
 		
-		if(res >= ng.settings.get("resUpperTreshold"))
+		if(res > ng.settings.get("resUpperTreshold") && ng.settings.get("resUpperTresholdChange") < 0)
+			res = Math.max((int)(res + ng.settings.get("resUpperTresholdChange")), (int)(0 + ng.settings.get("resUpperTreshold")));
+		else if(res > ng.settings.get("resUpperTreshold") && ng.settings.get("resUpperTresholdChange") > 0)
 			res += ng.settings.get("resUpperTresholdChange");
-		if(res <= ng.settings.get("resLowerTreshold"))
+		if(res < ng.settings.get("resLowerTreshold") && ng.settings.get("resLowerTresholdChange") > 0)
+			res = Math.min((int)(res + ng.settings.get("resLowerTresholdChange")), (int)(0 + ng.settings.get("resLowerTreshold")));
+		else if(res < ng.settings.get("resLowerTreshold") && ng.settings.get("resLowerTresholdChange") < 0)
 			res += ng.settings.get("resLowerTresholdChange");
-		if(gold >= ng.settings.get("goldUpperTreshold"))
+		if(gold > ng.settings.get("goldUpperTreshold") && ng.settings.get("goldUpperTresholdChange") < 0)
+			gold = Math.max((int)(gold + ng.settings.get("goldUpperTresholdChange")), (int)(0 + ng.settings.get("goldUpperTreshold")));
+		else if(gold > ng.settings.get("goldUpperTreshold") && ng.settings.get("goldUpperTresholdChange") > 0)
 			gold += ng.settings.get("goldUpperTresholdChange");
-		if(gold <= ng.settings.get("goldLowerTreshold"))
+		if(gold < ng.settings.get("goldLowerTreshold") && ng.settings.get("goldLowerTresholdChange") > 0)
+			gold = Math.min((int)(gold + ng.settings.get("goldLowerTresholdChange")), (int)(0 + ng.settings.get("goldLowerTreshold")));
+		else if(gold < ng.settings.get("goldLowerTreshold") && ng.settings.get("goldLowerTresholdChange") < 0)
 			gold += ng.settings.get("goldLowerTresholdChange");
 		
-		if(res >= ng.settings.get("resMultiTreshold"))
-			res *= ng.settings.get("resMulti");
+		
+		if(res > ng.settings.get("resMultiTreshold"))
+			res = (int)(ng.settings.get("resMultiTreshold") + (res - ng.settings.get("resMultiTreshold")) * ng.settings.get("resMulti"));
 		
 		// The higher the score, the smaller your starting army will be:
 		// 20 / (rescost + goldcost) * 10 * militiaMultiplier = amount of specified unit in militia


### PR DESCRIPTION
NationGen had been doing a reasonable job of getting PD numbers so long as the troops had fairly close to average res/gold, but they were ending up with some fairly outrageous outliers (e.g., nations with slaves who were ending up with close to 30 per 10). Vanilla is pretty dull on this count, and has nations showing up with 10 troops per type across a whole range of res costs, but rarely gets above 15 per and never above 20 per.

I fixed the code so it was actually doing what it claimed in re: the resMultiT[h]reshold. I also added checks so upper threshold modifiers couldn't reduce res/gold below the threshold, nor lower ones above the threshold. This eliminated some weird things like "13 & 15 are worth 13 res points but 14 is worth 12"; in this case (14/-2) it's now 13->13, 14->14, 15->14, 16->14, 17->15, etc.

I also played with the numbers some:
* Res upper threshold is now 10/-6, so the first 6 points above 10 are free.
* Res lower threshold is now 6/3, so 6 is a lot more common and l.t. 3 should be impossible
* Gold upper threshold is now 29/10, so more than medium-high-priced units have far fewer troops
* Gold lower threshold is now 6/3, so 6 is a lot more common and l.t. 3 should be impossible
* Res multi is now 16/0.7

Overall, I'm reasonably happy with the numbers of PD this produces. It's a lot smoother. There's still higher numbers of weak PD than vanilla usually gives, but not as extreme by a long shot.