### PR TITLE
Re-implement variable PD ranks

### DIFF
--- a/src/nationGen/nation/Nation.java
+++ b/src/nationGen/nation/Nation.java
@@ -578,14 +578,13 @@ public class Nation {
     		if(Generic.containsTag(this.races.get(0).tags, "extrapdmulti"))
     			extraPDMulti = Double.parseDouble(Generic.getTagValue(this.races.get(0).tags, "extrapdmulti"));
 
-    		//PD ranks will always equal 2 right now, as there is a serious bug in Dom5 when land PD has more than 2 ranks
-            /*if(random.nextDouble() < 0.1 * extraPDMulti)
+    		if(random.nextDouble() < 0.1 * extraPDMulti)
             {
             	if(random.nextDouble() < 0.02 * extraPDMulti)
             		PDRanks = 4;
             	else
             		PDRanks = 3;
-            }*/
+            }
             
             //finalizeUnits();
 	}


### PR DESCRIPTION
* As 5.23 fixed the bug with 3-4 ranks of PD, the feature to occassionally use those is re-implemented.
* Closes #961