### PR TITLE
Add Restriction Type for Recruit Anywhere Sacreds

### DIFF
--- a/src/nationGen/GUI/RestrictionPane.java
+++ b/src/nationGen/GUI/RestrictionPane.java
@@ -25,18 +25,7 @@ import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 
 import nationGen.NationGen;
-import nationGen.restrictions.MagicAccessRestriction;
-import nationGen.restrictions.MageWithAccessRestriction;
-import nationGen.restrictions.MagicDiversityRestriction;
-import nationGen.restrictions.NationThemeRestriction;
-import nationGen.restrictions.NoPrimaryRaceRestriction;
-import nationGen.restrictions.NoUnitOfRaceRestriction;
-import nationGen.restrictions.PrimaryRaceRestriction;
-import nationGen.restrictions.SacredRaceRestriction;
-import nationGen.restrictions.NationRestriction;
-import nationGen.restrictions.UnitCommandRestriction;
-import nationGen.restrictions.UnitFilterRestriction;
-import nationGen.restrictions.UnitOfRaceRestriction;
+import nationGen.restrictions.*;
 
 public class RestrictionPane extends JPanel implements ActionListener, ListSelectionListener {
 
@@ -75,6 +64,7 @@ public class RestrictionPane extends JPanel implements ActionListener, ListSelec
 			new NoPrimaryRaceRestriction(ng),
 			new NoUnitOfRaceRestriction(ng),
 			new PrimaryRaceRestriction(ng),
+			new RecAnywhereSacredsRestriction(ng),
 			new SacredRaceRestriction(ng),			// "Sacred: Race"
 			new UnitCommandRestriction(ng),
 			new UnitFilterRestriction(ng),

--- a/src/nationGen/nation/Nation.java
+++ b/src/nationGen/nation/Nation.java
@@ -60,6 +60,7 @@ import nationGen.restrictions.SacredRaceRestriction;
 import nationGen.restrictions.UnitCommandRestriction;
 import nationGen.restrictions.UnitFilterRestriction;
 import nationGen.restrictions.UnitOfRaceRestriction;
+import nationGen.restrictions.RecAnywhereSacredsRestriction;
 import nationGen.rostergeneration.CommanderGenerator;
 import nationGen.rostergeneration.HeroGenerator;
 import nationGen.rostergeneration.MonsterGenerator;
@@ -510,10 +511,12 @@ public class Nation {
             NoUnitOfRaceRestriction noUnitOfRaceRestriction = new NoUnitOfRaceRestriction(nationGen);
             PrimaryRaceRestriction primaryRaceRestriction = new PrimaryRaceRestriction(nationGen);
             SacredRaceRestriction sacredRaceRestriction = new SacredRaceRestriction(nationGen);
+            RecAnywhereSacredsRestriction recAnywhereSacredRestriction = new RecAnywhereSacredsRestriction(nationGen);
             UnitCommandRestriction unitCommandRestriction = new UnitCommandRestriction(nationGen);
             UnitFilterRestriction unitFilterRestriction = new UnitFilterRestriction(nationGen);
             UnitOfRaceRestriction unitOfRaceRestriction = new UnitOfRaceRestriction(nationGen);
-
+            	
+            
             @SuppressWarnings("rawtypes")
 			List<Class> restrictionTypes = new ArrayList<>();
             restrictionTypes.add(primaryRaceRestriction.getClass());
@@ -541,6 +544,7 @@ public class Nation {
             }
             restrictionTypes.clear();
             restrictionTypes.add(sacredRaceRestriction.getClass());
+            restrictionTypes.add(recAnywhereSacredRestriction.getClass());
             
             generateTroops();
             generateSacreds();

--- a/src/nationGen/restrictions/RecAnywhereSacredsRestriction.java
+++ b/src/nationGen/restrictions/RecAnywhereSacredsRestriction.java
@@ -1,0 +1,62 @@
+package nationGen.restrictions;
+
+import java.awt.BorderLayout;
+import java.awt.LayoutManager;
+
+import javax.swing.JPanel;
+
+import nationGen.NationGen;
+import nationGen.nation.Nation;
+import nationGen.units.Unit;
+
+/**
+ * 
+ * @author Flashfire
+ * Class intends to filter out nations that have recruit anywhere sacreds.
+ */
+public class RecAnywhereSacredsRestriction extends NationRestriction {
+
+	private NationGen ng; //everyone else needs one of these boys. May as well have it I suppose.
+	public RecAnywhereSacredsRestriction(NationGen nationGen)
+	{
+		this.ng = nationGen;
+	}
+	
+	@Override
+	// No need for a fancy (or even unfancy!) UI for just a simple flag!
+	public void getGUI(JPanel panel) {
+	}
+
+	@Override
+	public NationRestriction getRestriction() {
+		return new RecAnywhereSacredsRestriction(ng);
+	}
+
+	@Override
+	public LayoutManager getLayout() {
+		return new BorderLayout();
+	}
+
+	@Override
+	public boolean doesThisPass(Nation n) {
+		for(Unit u : n.generateUnitList("sacred"))
+		{
+			if(!u.caponly)
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public String toString() {
+		return "Recruit Anywhere Sacred";
+	}
+
+	@Override
+	public NationRestriction getInstanceOf() {
+		return new RecAnywhereSacredsRestriction(ng);
+	}
+
+}


### PR DESCRIPTION
This will allow people to filter out sacreds such that only recruit anywhere sacreds appear.  Seems like a good feature to have!

I also cleaned up the includes a bit in RestrictionPane.java since if you're including all the restrictions may as well just use .* instead.

Let me know if there's anything to be changed for style. Cheers