### PR TITLE
Fix UI Sluggishness When Generating Large Nation Amounts

### DIFF
--- a/src/nationGen/NationGen.java
+++ b/src/nationGen/NationGen.java
@@ -215,6 +215,7 @@ public class NationGen
         int count = 0;
         int failedcount = 0;
         int totalfailed = 0;
+        boolean isDebug = settings.get("debug") == 1.0;
         
         while(generatedNations.size() < amount)
         {
@@ -222,43 +223,56 @@ public class NationGen
             if(!manyseeds)
             {
                 newseed = random.nextInt();
-            }
+            } 
             else
             {
                 newseed = seeds.get(generatedNations.size());
             }
 
-            System.out.print("- Generating nation " + (generatedNations.size() + 1) + "/" + amount + " (seed " + newseed);
-            
-            if(settings.get("debug") == 1.0)
+            if (isDebug)
             {
+                System.out.print("- Generating nation " + (generatedNations.size() + 1) + "/" + amount + " (seed " + newseed);
                 System.out.print(" / " + ZonedDateTime.now().toLocalTime().truncatedTo(ChronoUnit.SECONDS));
+                System.out.print(")... ");
             }
-
-            System.out.print(")... ");
 
             newnation = new Nation(this, newseed, count, restrictions);
-            
-            if(!newnation.passed)
-            {
-                ++failedcount;
-                System.out.println("try "+ String.valueOf(failedcount) + ", FAILED RESTRICTION "  + newnation.restrictionFailed);
-            }
 
-            if(newnation.passed)
+            if (newnation.passed)
             {
+                if (restrictions.size() == 0)
+                {
+                    System.out.format("- Successfully generated nation %d/%d (seed %d)\n",
+                            generatedNations.size() + 1, amount, newseed);
+                } 
+                else
+                {
+                    System.out.format("- After failing %d attempt(s), successfully generated nation %d/%d (seed %d)\n",
+                            failedcount, generatedNations.size() + 1, amount, newseed);
+                }
                 totalfailed += failedcount;
                 failedcount = 0;
-                System.out.println("Done!");
             }
             else
             {
+                ++failedcount;
+                if (isDebug)
+                {
+                    System.out.println("try " + failedcount + ", FAILED RESTRICTION " + newnation.restrictionFailed);
+                } 
+                else if (failedcount % 250 == 0)
+                {
+                    // This is honestly a workaround to showing progress without destroying the UI.
+                    // Ideally, there'd be a label that shows the current gen. But, I'm saving a UI
+                    // rewrite for a future date.
+                    System.out.format("- Failed to generate nation after %d attempts.\n", failedcount);
+                }
                 continue;
             }
 
             // Handle loose ends
             newnation.nationid = idHandler.nextNationId();
-            this.polishNation(newnation);
+            polishNation(newnation);
 
             newnation.name = "Nation " + count;
 


### PR DESCRIPTION
For some reason, the append operation of Swing's log frame isn't constant time. This means that with too much text in the log frame, the UI freezes.

So, the fix?

Reduce log spam significantly.
I highly doubt any non-dev cares why a seed fails, especially thousands of them. So, I moved that to debug prints only. Then, I added an occasional print (every 250 gens), so they know that *something* is happening.



![image](https://user-images.githubusercontent.com/6501945/41545388-ab1296d2-72e0-11e8-864a-d7189a40bf8f.png)

Here's what the new output looks like! (pretend the -'s exist, I put them back in after the screenshot)