### PR TITLE
Make Seeds 64 Bits

### DIFF
--- a/src/nationGen/GUI/CommandLine.java
+++ b/src/nationGen/GUI/CommandLine.java
@@ -10,9 +10,9 @@ import nationGen.NationGen;
 public class CommandLine {
 	public CommandLine (String[] args) throws Exception
 	{
-		Integer seed = null;
+		Long seed = null;
 		int amount = 0;
-		List<Integer> seeds = new ArrayList<Integer>();
+		List<Long> seeds = new ArrayList<Long>();
 		int settings = 0;
 		boolean nextseed = false;
 		boolean nextamount = false;
@@ -54,13 +54,13 @@ public class CommandLine {
 			else if(Generic.isNumeric(str))
 			{
 				if(nextseed)
-					seed = Integer.parseInt(str);
+					seed = Long.parseLong(str);
 				if(nextamount)
 					amount = Integer.parseInt(str);
 				if(nextsettings)
 					settings = Integer.parseInt(str);
 				if(nextnseed)
-					seeds.add(Integer.parseInt(str));
+					seeds.add(Long.parseLong(str));
 					
 			}
 			else if(nextname)

--- a/src/nationGen/GUI/ConsoleGUI.java
+++ b/src/nationGen/GUI/ConsoleGUI.java
@@ -17,8 +17,8 @@ public class ConsoleGUI {
 		
 		NationGen nationGen = new NationGen();
 
-		List<Integer> seeds = new ArrayList<Integer>();
-		seeds.add(-216802392);
+		List<Long> seeds = new ArrayList<Long>();
+		seeds.add(-216802392L);
 		
 		//nationGen.settings.put("era", 2.0);
 		nationGen.settings.put("drawPreview", 1.0);

--- a/src/nationGen/GUI/GUI.java
+++ b/src/nationGen/GUI/GUI.java
@@ -348,9 +348,9 @@ public class GUI extends JFrame implements ActionListener, ItemListener, ChangeL
         });
     }
     
-    private List<Integer> parseSeeds()
+    private List<Long> parseSeeds()
     {
-    	List<Integer> l = new ArrayList<>();
+    	List<Long> l = new ArrayList<>();
     	String text = seeds.getText();
     	
     	String[] parts = text.split(",");
@@ -361,7 +361,7 @@ public class GUI extends JFrame implements ActionListener, ItemListener, ChangeL
             {
                 if(Generic.isNumeric(str2.trim()))
                 {
-                    l.add(Integer.parseInt(str2.trim()));
+                    l.add(Long.parseLong(str2.trim()));
                 }
             }
     	}
@@ -432,7 +432,7 @@ public class GUI extends JFrame implements ActionListener, ItemListener, ChangeL
                     {
                         if(!seedRandom.isSelected())
                         {
-                            n.generate(Integer.parseInt(amount.getText()), Integer.parseInt(seed.getText()));
+                            n.generate(Integer.parseInt(amount.getText()), Long.parseLong(seed.getText()));
                         }
                         else
                         {

--- a/src/nationGen/NationGen.java
+++ b/src/nationGen/NationGen.java
@@ -164,28 +164,28 @@ public class NationGen
         //this.writeDebugInfo();
     }
 	
-    public int seed = 0;
+    public long seed = 0;
     public String modname = "";
     public boolean manyseeds = false;
 
     public void generate(int amount) throws IOException
     {
         Random random = new Random();
-        generate(amount, random.nextInt(), null);
+        generate(amount, random.nextLong(), null);
     }
     
-    public void generate(int amount, int seed) throws IOException
+    public void generate(int amount, long seed) throws IOException
     {
         generate(amount, seed, null);
     }
     
-    public void generate(List<Integer> seeds) throws IOException
+    public void generate(List<Long> seeds) throws IOException
     {
         Random random = new Random();
-        generate(1, random.nextInt(), seeds);
+        generate(1, random.nextLong(), seeds);
     }
 	
-    private void generate(int amount, int seed, List<Integer> seeds) throws IOException
+    private void generate(int amount, long seed, List<Long> seeds) throws IOException
     {
         shouldAbort = false; // Don't abort before you even start.
         
@@ -223,7 +223,7 @@ public class NationGen
         System.out.println("Generating nations...");
         List<Nation> generatedNations = new ArrayList<>();
         Nation newnation = null;
-        int newseed = 0;
+        long newseed = 0;
 
         int count = 0;
         int failedcount = 0;
@@ -247,8 +247,8 @@ public class NationGen
             count++;
             if(!manyseeds)
             {
-                newseed = random.nextInt();
-            } 
+                newseed = random.nextLong();
+            }
             else
             {
                 newseed = seeds.get(generatedNations.size());
@@ -607,7 +607,7 @@ public class NationGen
 
         for(Nation n : nations)
         {
-            tw.println("-- Nation " + n.nationid + ": " + n.name + " generated with seed " + n.seed);
+            tw.println("-- Nation " + n.nationid + ": " + n.name + " generated with seed " + n.getSeed());
         }
         tw.println("-----------------------------------");
         tw.println();

--- a/src/nationGen/magic/MageGenerator.java
+++ b/src/nationGen/magic/MageGenerator.java
@@ -1924,7 +1924,7 @@ public class MageGenerator extends TroopGenerator {
 							maxpower = f.power;
 					}
 					else
-						System.out.println("Nation " + nation.seed + " had a null filter for a mage. Power was " + power + " and tier " + tier + ".");
+						System.out.println("Nation " + nation.getSeed() + " had a null filter for a mage. Power was " + power + " and tier " + tier + ".");
 					
 				}
 				power -= maxpower;
@@ -2802,7 +2802,7 @@ public class MageGenerator extends TroopGenerator {
 		
 		if(possibles.size() == 0)
 		{
-			System.out.println("CRITICAL ERROR: No possible pose for " + race.name + " " + posename + " for tier " + tier + ". Nation seed: " + nation.seed +  " and main race " + nation.races.get(0));
+			System.out.println("CRITICAL ERROR: No possible pose for " + race.name + " " + posename + " for tier " + tier + ". Nation seed: " + nation.getSeed() +  " and main race " + nation.races.get(0));
 		}
 		return possibles;
 			

--- a/src/nationGen/nation/Nation.java
+++ b/src/nationGen/nation/Nation.java
@@ -84,7 +84,7 @@ public class Nation {
         public boolean passed = true;
         public String restrictionFailed = "";
 	public NationGen nationGen;
-	public int seed = 0;
+	private long seed = 0;
 	
 	public ItemSet usedItems = new ItemSet();
 	public Random random;
@@ -115,7 +115,7 @@ public class Nation {
 	
 	public int PDRanks = 2;
 
-	public Nation(NationGen ngen, int seed, int tempid, List restrictions)
+	public Nation(NationGen ngen, long seed, int tempid, List<NationRestriction> restrictions)
 	{
 		this.nationid = tempid;
 		this.nationGen = ngen;
@@ -131,6 +131,10 @@ public class Nation {
 		generate(restrictions);
 	}
 	
+	public long getSeed()
+	{
+	    return seed;
+	}
 	
 	private void getColors()
 	{


### PR DESCRIPTION
With my last change, I noticed a user in discord running nearly a million iterations.  That's 0.02% of the seed space itself. Unacceptable.

Anyways, change the type of the seed from Integer to Long. While, this technically appears to not change the result of a given nation, it will change stuff if you use a fixed seed to generate an assortment of nations.

NOTE: I haven't tested the console. But, I've tested the GUI fairly extensively, IMO.