### PR TITLE
Fix Natgen Export in IDE

### DIFF
--- a/src/nationGen/NationGen.java
+++ b/src/nationGen/NationGen.java
@@ -581,8 +581,8 @@ public class NationGen
     public void write(List<Nation> nations, String modname) throws IOException
     {
         String dir = "nationgen_" + modname.toLowerCase().replaceAll(" ", "_") + "/"; // nation.name.toLowerCase().replaceAll(" ", "_")
-        new File("./mods/" + dir).mkdir();
-
+        new File("./mods/" + dir).mkdirs();
+        
         FileWriter fstream = new FileWriter("./mods/nationgen_" + modname.toLowerCase().replaceAll(" ", "_") + ".dm");
         PrintWriter tw = new PrintWriter(fstream, true);
 


### PR DESCRIPTION
Mods directory doesn't exist by default in the working dir of Eclipse when running this project [the root of the repo].  So, you need to use mkdirs. Then, the mod directory exists. This will fix the failed exports when running in IDEs. 