### PR TITLE
Settings improvements: Enums/type Safety

### DIFF
--- a/src/nationGen/GUI/ConsoleGUI.java
+++ b/src/nationGen/GUI/ConsoleGUI.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import nationGen.NationGen;
+import nationGen.Settings.SettingsType;
 
 public class ConsoleGUI {
 	
@@ -21,8 +22,8 @@ public class ConsoleGUI {
 		seeds.add(-216802392L);
 		
 		//nationGen.settings.put("era", 2.0);
-		nationGen.settings.put("drawPreview", 1.0);
-		nationGen.settings.put("debug", 1.0);
+		nationGen.settings.put(SettingsType.drawPreview, 1.0);
+		nationGen.settings.put(SettingsType.debug, 1.0);
 		nationGen.generate(seeds);
 		//nationGen.generate(10, 403);
 	}

--- a/src/nationGen/GUI/GUI.java
+++ b/src/nationGen/GUI/GUI.java
@@ -44,6 +44,7 @@ import com.elmokki.Generic;
 
 import nationGen.NationGen;
 import nationGen.Settings;
+import nationGen.Settings.SettingsType;
 
 public class GUI extends JFrame implements ActionListener, ItemListener, ChangeListener 
 {
@@ -302,8 +303,8 @@ public class GUI extends JFrame implements ActionListener, ItemListener, ChangeL
     
     private void updateAdvancedSettings()
     {
-    	this.eraSlider.setValue(settings.get("era").intValue());
-    	this.spowerSlider.setValue(settings.get("sacredpower").intValue());
+    	this.eraSlider.setValue(settings.get(SettingsType.era).intValue());
+    	this.spowerSlider.setValue(settings.get(SettingsType.sacredpower).intValue());
 
     }
     
@@ -314,23 +315,23 @@ public class GUI extends JFrame implements ActionListener, ItemListener, ChangeL
         this.setResizable(true);
         initGUI();
     	
-    	if(this.settings.get("drawPreview") == 1.0)
+    	if(this.settings.get(SettingsType.drawPreview) == 1.0)
         {
             preview.setSelected(true);
         }
-    	if(this.settings.get("advancedDescs") == 1.0)
+    	if(this.settings.get(SettingsType.advancedDescs) == 1.0)
         {
             advDesc.setSelected(true);
         }
-    	if(this.settings.get("basicDescs") == 1.0)
+    	if(this.settings.get(SettingsType.basicDescs) == 1.0)
         {
             basicDesc.setSelected(true);
         }
-    	if(this.settings.get("hidevanillanations") == 1.0)
+    	if(this.settings.get(SettingsType.hidevanillanations) == 1.0)
         {
             hideVanillaNations.setSelected(true);
         }
-    	this.eraSlider.setValue((int)Math.round(this.settings.get("era")));
+    	this.eraSlider.setValue((int)Math.round(this.settings.get(SettingsType.era)));
      }
     
     private void updateTextPane(final String text) 
@@ -572,19 +573,19 @@ public class GUI extends JFrame implements ActionListener, ItemListener, ChangeL
             }
             if(source == this.preview)
             {
-                settings.put("drawPreview", value);
+                settings.put(SettingsType.drawPreview, value);
             }
             if(source == this.advDesc)
             {
-                settings.put("advancedDescs", value);
+                settings.put(SettingsType.advancedDescs, value);
             }
             if(source == this.basicDesc)
             {
-                settings.put("basicDescs", value);
+                settings.put(SettingsType.basicDescs, value);
             }
             if(source == this.hideVanillaNations)
             {
-                settings.put("hidevanillanations", value);
+                settings.put(SettingsType.hidevanillanations, value);
             }
             if(source == this.seedcheckbox)
             {
@@ -602,12 +603,12 @@ public class GUI extends JFrame implements ActionListener, ItemListener, ChangeL
         Object source = e.getSource();
         if(source == this.eraSlider && eraSlider.getValueIsAdjusting())
         {
-            settings.put("era", eraSlider.getValue());
+            settings.put(SettingsType.era, eraSlider.getValue());
             settingtext.setText(settings.getSettingInteger() + "");
         }
         if(source == this.spowerSlider && spowerSlider.getValueIsAdjusting())
         {
-            settings.put("sacredpower", spowerSlider.getValue());
+            settings.put(SettingsType.sacredpower, spowerSlider.getValue());
             settingtext.setText(settings.getSettingInteger() + "");
         }
     }

--- a/src/nationGen/NationGen.java
+++ b/src/nationGen/NationGen.java
@@ -26,6 +26,7 @@ import com.elmokki.Dom3DB;
 import com.elmokki.Drawing;
 import com.elmokki.Generic;
 
+import nationGen.Settings.SettingsType;
 import nationGen.entities.Entity;
 import nationGen.entities.Filter;
 import nationGen.entities.Flag;
@@ -217,7 +218,7 @@ public class NationGen
         int count = 0;
         int failedcount = 0;
         int totalfailed = 0;
-        boolean isDebug = settings.get("debug") == 1.0;
+        boolean isDebug = settings.get(SettingsType.debug) == 1.0;
         
         while(generatedNations.size() < amount)
         {  
@@ -479,7 +480,7 @@ public class NationGen
                 this.freeSpells.add(spell);
             }
 
-            if(spell.nationids.size() >= settings.get("maxrestrictedperspell"))
+            if(spell.nationids.size() >= settings.get(SettingsType.maxrestrictedperspell))
             {
                 this.freeSpells.remove(spell);
             }
@@ -541,11 +542,11 @@ public class NationGen
     private void writeDescriptions(PrintWriter tw, List<Nation> nations, String modname) throws IOException
     {
         NationAdvancedSummarizer nDesc = new NationAdvancedSummarizer(armordb, weapondb);
-        if(settings.get("advancedDescs") == 1.0)
+        if(settings.get(SettingsType.advancedDescs) == 1.0)
         {
             nDesc.writeAdvancedDescriptionFile(nations, modname);
         }
-        if(settings.get("basicDescs") == 1.0)
+        if(settings.get(SettingsType.basicDescs) == 1.0)
         {
             nDesc.writeDescriptionFile(nations, modname);
         }   
@@ -553,7 +554,7 @@ public class NationGen
 	
     private void drawPreviews(List<Nation> nations, String dir) throws IOException
     {
-        if(settings.get("drawPreview") == 1)
+        if(settings.get(SettingsType.drawPreview) == 1)
         {
             System.out.print("Drawing previews");
             PreviewGenerator pGen = new PreviewGenerator();
@@ -659,7 +660,7 @@ public class NationGen
         // Draw previews
         drawPreviews(nations, dir);
         
-        if(settings.get("hidevanillanations") == 1)
+        if(settings.get(SettingsType.hidevanillanations) == 1)
         {
             hideVanillaNations(tw, nations.size());
         }

--- a/src/nationGen/Settings.java
+++ b/src/nationGen/Settings.java
@@ -3,7 +3,6 @@ package nationGen;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -19,25 +18,52 @@ import java.util.Scanner;
 
 import com.elmokki.Generic;
 
-
-
-
 public class Settings {
-	
+	public enum SettingsType {
+	    advancedDescs,
+	    basicDescs,
+	    separateSeeds,
+	    seedsFromFile,
+	    maxrestrictedperspell,
+	    era,
+	    sacredpower,
+	    militiaMultiplier,
+	    resUpperTreshold,
+	    resUpperTresholdChange,
+	    goldUpperTreshold,
+	    goldUpperTresholdChange,
+	    resLowerTreshold,
+	    resLowerTresholdChange,
+	    goldLowerTreshold,
+	    goldLowerTresholdChange,
+	    resMultiTreshold,
+	    resMulti,
+	    desiredBaseSize,
+	    desiredRandom,
+	    cavalryPower,
+	    chariotPower,
+	    rangedPower,
+	    infantryPower,
+	    newArmorChance,
+	    debug,
+	    drawPreview,
+	    hidevanillanations;
+	 }
+    
 	private class SettingEntry {
-		public String key;
+		public SettingsType key;
 		public Double value;
 		
-		public SettingEntry(String k, Double v)
+		public SettingEntry(SettingsType k, Double v)
 		{
-			key = k;
-			value = v;
+            key = k;
+            value = v;  
 		}
 
 	}
 
 	
-	public HashMap<String, Double> settings = new HashMap<String, Double>();
+	public HashMap<SettingsType, Double> settings = new HashMap<SettingsType, Double>();
 	public HashMap<String, String> descs = new HashMap<String, String>();
 	
 	public LinkedList<SettingEntry> exportvalues = new LinkedList<SettingEntry>();
@@ -53,18 +79,18 @@ public class Settings {
 		// Settings
 		
 		// 1: Early era
-		exportvalues.add(new SettingEntry("era", 1.0));
+		exportvalues.add(new SettingEntry(SettingsType.era, 1.0));
 		// 2: Late era
-		exportvalues.add(new SettingEntry("era", 3.0));
+		exportvalues.add(new SettingEntry(SettingsType.era, 3.0));
 		// 4: Powerful sacreds
-		exportvalues.add(new SettingEntry("sacredpower", 2.0));
+		exportvalues.add(new SettingEntry(SettingsType.sacredpower, 2.0));
 		// 8: Batshit insane sacreds
-		exportvalues.add(new SettingEntry("sacredpower", 3.0));
+		exportvalues.add(new SettingEntry(SettingsType.sacredpower, 3.0));
 
 		
 		// Defaults
-		defaultvalues.add(new SettingEntry("era", 2.0));
-		defaultvalues.add(new SettingEntry("sacredpower", 1.0));
+		defaultvalues.add(new SettingEntry(SettingsType.era, 2.0));
+		defaultvalues.add(new SettingEntry(SettingsType.sacredpower, 1.0));
 
 	}
 	
@@ -129,36 +155,20 @@ public class Settings {
 	public Settings()
 	{
 		setExportValues();
-
-		// Militia
-		settings.put("militiaResMulti", -0.1333);
-		settings.put("militiaLowResMulti", -0.125);
-		settings.put("militiaResIntercept", 1.333);
-		settings.put("militiaLowResIntercept", 2.5);
-		
-		settings.put("militiaGoldMulti", -0.1);
-		settings.put("militiaLowGoldMulti", -1.666);
-		settings.put("militiaGoldIntercept", 1.0);
-		settings.put("militiaLowGoldIntercept", 16.66);
-		
 		
 		// spells
-		settings.put("maxrestrictedperspell", 8.0);
+		settings.put(SettingsType.maxrestrictedperspell, 8.0);
 		
-		// Debug
-		
-		settings.put("debug", 0.0);
-
-		// Items
-		settings.put("weaponGenerationChance", 0.3);
+		// Debug	
+		settings.put(SettingsType.debug, 0.0);
 		
 		// POWER (ranges from 1 to 3, integers only)
-		settings.put("sacredpower", 1.0);
+		settings.put(SettingsType.sacredpower, 1.0);
 		
-		settings.put("drawPreview", 0.0);
+		settings.put(SettingsType.drawPreview, 0.0);
 
-		settings.put("era", 2.0);
-		settings.put("hidevanillanations", 1.0);
+		settings.put(SettingsType.era, 2.0);
+		settings.put(SettingsType.hidevanillanations, 1.0);
 
         Scanner file;
 		
@@ -178,7 +188,7 @@ public class Settings {
 				continue;
 			
 			
-			settings.put(args.get(0), Double.parseDouble(args.get(1)));
+			settings.put(SettingsType.valueOf(args.get(0)), Double.parseDouble(args.get(1)));
 		}
 		
 		file.close();
@@ -204,7 +214,7 @@ public class Settings {
                 continue;
             }
             
-            String key = args.get(0);
+            SettingsType key = SettingsType.valueOf(args.get(0));
             String val = args.get(1);
             
             if (settings.containsKey(key) && Double.parseDouble(val) != settings.get(key))
@@ -223,9 +233,9 @@ public class Settings {
 	}
 	
 	
-	public void put(String name, double value)
+	public void put(SettingsType key, double value)
 	{
-		settings.put(name, value);
+		settings.put(key, value);
         try
         {
             write();
@@ -235,13 +245,13 @@ public class Settings {
         }
 	}
 	
-	public Double get(String name)
+	public Double get(SettingsType key)
 	{
 		Double d = 0.0;
-		if(settings.get(name) != null)
-			d = settings.get(name);
+		if(settings.get(key) != null)
+			d = settings.get(key);
 		else
-			System.out.println("SETTING " + name + " WAS NOT DEFINED!");
+			System.out.println("SETTING " + key + " WAS NOT DEFINED!");
 		
 		return d;
 	}

--- a/src/nationGen/Settings.java
+++ b/src/nationGen/Settings.java
@@ -63,11 +63,10 @@ public class Settings {
 	}
 
 	
-	public HashMap<SettingsType, Double> settings = new HashMap<SettingsType, Double>();
-	public HashMap<String, String> descs = new HashMap<String, String>();
+	private HashMap<SettingsType, Double> settings = new HashMap<SettingsType, Double>();
 	
-	public LinkedList<SettingEntry> exportvalues = new LinkedList<SettingEntry>();
-	public LinkedList<SettingEntry> defaultvalues = new LinkedList<SettingEntry>();
+	private LinkedList<SettingEntry> exportvalues = new LinkedList<SettingEntry>();
+	private LinkedList<SettingEntry> defaultvalues = new LinkedList<SettingEntry>();
 	
 	
 	/**

--- a/src/nationGen/nation/Nation.java
+++ b/src/nationGen/nation/Nation.java
@@ -33,6 +33,7 @@ import com.elmokki.Drawing;
 import com.elmokki.Generic;
 
 import nationGen.NationGen;
+import nationGen.Settings.SettingsType;
 import nationGen.entities.Entity;
 import nationGen.entities.Filter;
 import nationGen.entities.Race;
@@ -121,7 +122,7 @@ public class Nation {
 		this.nationGen = ngen;
 		this.random = new Random(seed);
 		this.seed = seed;
-		this.era = (int)Math.round(nationGen.settings.get("era"));
+		this.era = (int)Math.round(nationGen.settings.get(SettingsType.era));
 		
 		comlists.put("scouts", new ArrayList<Unit>());
 		comlists.put("commanders", new ArrayList<Unit>());

--- a/src/nationGen/nation/PDSelector.java
+++ b/src/nationGen/nation/PDSelector.java
@@ -7,6 +7,7 @@ import java.util.Random;
 import com.elmokki.Generic;
 
 import nationGen.NationGen;
+import nationGen.Settings.SettingsType;
 import nationGen.misc.Command;
 import nationGen.units.Unit;
 
@@ -495,26 +496,26 @@ public class PDSelector {
 		int res = u.getResCost(true);
 		int gold = u.getGoldCost();
 		
-		if(res > ng.settings.get("resUpperTreshold") && ng.settings.get("resUpperTresholdChange") < 0)
-			res = Math.max((int)(res + ng.settings.get("resUpperTresholdChange")), (int)(0 + ng.settings.get("resUpperTreshold")));
-		else if(res > ng.settings.get("resUpperTreshold") && ng.settings.get("resUpperTresholdChange") > 0)
-			res += ng.settings.get("resUpperTresholdChange");
-		if(res < ng.settings.get("resLowerTreshold") && ng.settings.get("resLowerTresholdChange") > 0)
-			res = Math.min((int)(res + ng.settings.get("resLowerTresholdChange")), (int)(0 + ng.settings.get("resLowerTreshold")));
-		else if(res < ng.settings.get("resLowerTreshold") && ng.settings.get("resLowerTresholdChange") < 0)
-			res += ng.settings.get("resLowerTresholdChange");
-		if(gold > ng.settings.get("goldUpperTreshold") && ng.settings.get("goldUpperTresholdChange") < 0)
-			gold = Math.max((int)(gold + ng.settings.get("goldUpperTresholdChange")), (int)(0 + ng.settings.get("goldUpperTreshold")));
-		else if(gold > ng.settings.get("goldUpperTreshold") && ng.settings.get("goldUpperTresholdChange") > 0)
-			gold += ng.settings.get("goldUpperTresholdChange");
-		if(gold < ng.settings.get("goldLowerTreshold") && ng.settings.get("goldLowerTresholdChange") > 0)
-			gold = Math.min((int)(gold + ng.settings.get("goldLowerTresholdChange")), (int)(0 + ng.settings.get("goldLowerTreshold")));
-		else if(gold < ng.settings.get("goldLowerTreshold") && ng.settings.get("goldLowerTresholdChange") < 0)
-			gold += ng.settings.get("goldLowerTresholdChange");
+		if(res > ng.settings.get(SettingsType.resUpperTreshold) && ng.settings.get(SettingsType.resUpperTresholdChange) < 0)
+			res = Math.max((int)(res + ng.settings.get(SettingsType.resUpperTresholdChange)), (int)(0 + ng.settings.get(SettingsType.resUpperTreshold)));
+		else if(res > ng.settings.get(SettingsType.resUpperTreshold) && ng.settings.get(SettingsType.resUpperTresholdChange) > 0)
+			res += ng.settings.get(SettingsType.resUpperTresholdChange);
+		if(res < ng.settings.get(SettingsType.resLowerTreshold) && ng.settings.get(SettingsType.resLowerTresholdChange) > 0)
+			res = Math.min((int)(res + ng.settings.get(SettingsType.resLowerTresholdChange)), (int)(0 + ng.settings.get(SettingsType.resLowerTreshold)));
+		else if(res < ng.settings.get(SettingsType.resLowerTreshold) && ng.settings.get(SettingsType.resLowerTresholdChange) < 0)
+			res += ng.settings.get(SettingsType.resLowerTresholdChange);
+		if(gold > ng.settings.get(SettingsType.goldUpperTreshold) && ng.settings.get(SettingsType.goldUpperTresholdChange) < 0)
+			gold = Math.max((int)(gold + ng.settings.get(SettingsType.goldUpperTresholdChange)), (int)(0 + ng.settings.get(SettingsType.goldUpperTreshold)));
+		else if(gold > ng.settings.get(SettingsType.goldUpperTreshold) && ng.settings.get(SettingsType.goldUpperTresholdChange) > 0)
+			gold += ng.settings.get(SettingsType.goldUpperTresholdChange);
+		if(gold < ng.settings.get(SettingsType.goldLowerTreshold) && ng.settings.get(SettingsType.goldLowerTresholdChange) > 0)
+			gold = Math.min((int)(gold + ng.settings.get(SettingsType.goldLowerTresholdChange)), (int)(0 + ng.settings.get(SettingsType.goldLowerTreshold)));
+		else if(gold < ng.settings.get(SettingsType.goldLowerTreshold) && ng.settings.get(SettingsType.goldLowerTresholdChange) < 0)
+			gold += ng.settings.get(SettingsType.goldLowerTresholdChange);
 		
 		
-		if(res > ng.settings.get("resMultiTreshold"))
-			res = (int)(ng.settings.get("resMultiTreshold") + (res - ng.settings.get("resMultiTreshold")) * ng.settings.get("resMulti"));
+		if(res > ng.settings.get(SettingsType.resMultiTreshold))
+			res = (int)(ng.settings.get(SettingsType.resMultiTreshold) + (res - ng.settings.get(SettingsType.resMultiTreshold)) * ng.settings.get(SettingsType.resMulti));
 		
 		// The higher the score, the smaller your starting army will be:
 		// 20 / (rescost + goldcost) * 10 * militiaMultiplier = amount of specified unit in militia
@@ -526,7 +527,7 @@ public class PDSelector {
 		
 		double result = multi * 10;
 
-		result = result * ng.settings.get("militiaMultiplier");
+		result = result * ng.settings.get(SettingsType.militiaMultiplier);
 		
 
 		return result;

--- a/src/nationGen/rostergeneration/SacredGenerator.java
+++ b/src/nationGen/rostergeneration/SacredGenerator.java
@@ -7,6 +7,7 @@ import java.util.List;
 import com.elmokki.Generic;
 
 import nationGen.NationGen;
+import nationGen.Settings.SettingsType;
 import nationGen.entities.Entity;
 import nationGen.entities.Filter;
 import nationGen.entities.MagicItem;
@@ -513,7 +514,7 @@ public class SacredGenerator extends TroopGenerator {
 	public Pose getPose(boolean sacred, int power, Race race)
 	{
 		// Handle sacred power settings
-		double extrapower = this.nationGen.settings.get("sacredpower") - 1;
+		double extrapower = this.nationGen.settings.get(SettingsType.sacredpower) - 1;
 	
 		
 		power = (int) (power + power * extrapower * (1 + random.nextDouble() * 0.5) + extrapower);


### PR DESCRIPTION
Adding enums will make the code easier to use without mistakes. I removed a few export values that weren't referenced anywhere in the codebase.  So, would be useless.  If I made a mistake in removing the exports, that's trivial to reverse so I'm going to just merge.