### PR TITLE
Spellsingers, templetrainers added 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,15 +3,21 @@
 
 Code
 ----------------------------------------------------------
-- More variety in number of ranks of PD
+- More variety in number of ranks of PD (TODO: more variety in PD/castle commanders)
 -...
 
 Content
 -----------------------------------------------------------
-- Last small bows should be gone
-- Some new commander & priest names
-- Lictor-style non-legionaire sacreds for imperial nations
 - More ichtyid subtypes from Strabo: clownfishmen, pikemen, flying-fishmen, sailfishmen, anglerfishmen, perchmen, piranamen, sharkmen, catfishmen, tunamen, and swordfishmen
+- Lictor-style non-legionaire sacreds for imperial nations
+- A whole bunch of possible templetrainer priests, and some straight-up domsummon priests
+- Sidhe, fae-blooded nations, and elegists are spellsingers; boreal humans are occassionally spellsingers; other mages can have it as a filter
+- Some new spellsets for fae nations - seelie, unseelie, and old-fashioned-unseelie
+- Communion Choruses or Communion Dirges possible for nature or death nations with spellsingers
+- Some new commander & priest names
+- Last small bows should be gone
+- Assorted small bugfixes
+
 
 
 0.7.0-RC7 (6th of May 2018)

--- a/data/filters/default_magefilters.txt
+++ b/data/filters/default_magefilters.txt
@@ -29,6 +29,7 @@
 #chanceinc "personalmagic air *5"
 #chanceinc "personalmagic earth *2"
 #chanceinc "personalmagic water *0"
+#chanceinc "personalcommand aquatic *0"
 #command "#uwdamage 100"
 #notfortier 3
 #notfortier 2
@@ -107,6 +108,16 @@
 #chanceinc "personalmagic water 0.5"
 #chanceinc "personalmagic astral 0.5"
 #chanceinc "personalmagic water astral 0.8"
+#power 1
+#end
+
+#new magefilter
+#name "carcasscollector"
+#basechance 0.2
+#command "#carcasscollector 3"
+#chanceinc "personalmagic nature 0.5"
+#chanceinc "personalmagic death 0.5"
+#chanceinc "personalmagic nature death 0.8"
 #power 1
 #end
 
@@ -191,6 +202,7 @@
 #tag "personalmagic holy"
 #chanceinc "personalmagic holy 1.5"
 #command "#elegist +1"
+#command "#spellsinger"
 #notfortier 3
 #notfortier 2
 #end
@@ -202,6 +214,7 @@
 #chanceinc "personalmagic holy 0.8"
 #command "#elegist +2"
 #command "#gcost +5"
+#command "#spellsinger"
 #notfortier 1
 #end
 
@@ -212,6 +225,7 @@
 #chanceinc "personalmagic holy 0.8"
 #command "#elegist +3"
 #command "#gcost +25"
+#command "#spellsinger"
 #notfortier 1
 #notfortier 2
 #power 2
@@ -325,7 +339,7 @@
 
 #new magefilter
 #name "illusion"
-#basechance 0.0
+#basechance 0
 #command "#illusion"
 #command "#stealthy +0"
 #command "#gcost *1.05"
@@ -337,6 +351,19 @@
 #end
 
 #new magefilter
+#name "spellsinger"
+#basechance 0.2
+#command "#spellsinger"
+#primarycommand #spellsinger
+#chanceinc "personalmagic astral 0.3"
+#chanceinc "personalmagic death 0.3"
+#chanceinc "personalmagic nature 1.3"
+#power 1
+#chanceinc "race sidhe -20"
+#chanceinc "nationtag fae OR hasthemetheme fae -20"
+#end
+
+#new magefilter
 #name "holy"
 #basechance 0.2
 #primarycommand "#holy"
@@ -345,7 +372,7 @@
 
 #new magefilter
 #name "amphibian"
-#basechance 0.0
+#basechance 0
 #command "#amphibian"
 #chanceinc "personalmagic water 1"
 #tag "personalmagic water"

--- a/data/filters/default_nationwidefilters.txt
+++ b/data/filters/default_nationwidefilters.txt
@@ -68,6 +68,7 @@
 #description "Fae blood"
 #chance 0.3
 #command "#mr +1"
+#command "#spellsinger"
 #end
 
 #new
@@ -282,15 +283,8 @@
 #new
 #name "Hardy"
 #chance 0.05
-#command "#woundfend 20"
+#command "#woundfend +1"
 #description "Hardy"
-#end
-
-#new
-#name "Frail"
-#chance 0.05
-#command "#woundfend -20"
-#description "Frail"
 #end
 
 #new

--- a/data/filters/default_priestfilters.txt
+++ b/data/filters/default_priestfilters.txt
@@ -338,3 +338,331 @@
 #notfortier 2
 #description " Attracts revered ancestral spirits to their side."
 #end
+
+#new magefilter
+#name "serpent trainer"
+#type "leadership"
+#basechance 0.05
+#chanceinc "racetheme totemanimal OR unittheme totemanimal AND racetheme NOT snaketotem AND unittheme NOT snaketotem *0"
+#chanceinc "primaryrace 'Dynastic human' 0.25"
+#chanceinc "anymagic not nature *0"
+#chanceinc "primaryrace lizard 1"
+#command "#templetrainer 295"
+#notfortier 1
+#notfortier 3
+#description " Can train sacred serpents in temples."
+#theme "snaketotem"
+#theme "totemanimal"
+#end
+
+#new magefilter
+#name "hydra trainer"
+#type "leadership"
+#basechance 0.05
+#chanceinc "racetheme totemanimal OR unittheme totemanimal AND racetheme NOT snaketotem AND unittheme NOT snaketotem *0"
+#chanceinc "anymagic not nature *0"
+#command "#templetrainer 1859"
+#notfortier 1
+#notfortier 3
+#description " Can train sacred hydras in temples."
+#theme "snaketotem"
+#theme "totemanimal"
+#end
+
+#new magefilter
+#name "jaguar trainer"
+#type "leadership"
+#basechance 0.05
+#chanceinc "nationtag occidental 0.95"
+#chanceinc "racetheme totemanimal OR unittheme totemanimal AND racetheme NOT jaguartotem AND unittheme NOT jaguartotem *0"
+#chanceinc "anymagic not nature *0"
+#command "#gcost +20"
+#command "#templetrainer 859"
+#notfortier 1
+#notfortier 3
+#description " Can train sacred jaguars in temples."
+#theme "jaguartotem"
+#theme "totemanimal"
+#end
+
+#new magefilter
+#name "toad trainer"
+#type "leadership"
+#basechance 0.05
+#chanceinc "nationtag occidental 0.95"
+#chanceinc "racetheme totemanimal OR unittheme totemanimal AND racetheme NOT toadtotem AND unittheme NOT toadtotem *0"
+#chanceinc "anymagic not nature *0"
+#chanceinc "primaryrace muuch 1"
+#command "#gcost +20"
+#command "#templetrainer 1359"
+#notfortier 1
+#notfortier 3
+#description " Can train sacred toads in temples."
+#theme "toadtotem"
+#theme "totemanimal"
+#end
+
+#new magefilter
+#name "wolf trainer"
+#type "leadership"
+#basechance 0.05
+#chanceinc "nationtag boreal OR nationtag nordic 0.45"
+#chanceinc "racetheme totemanimal OR unittheme totemanimal AND racetheme NOT wolftotem AND unittheme NOT wolftotem *0"
+#chanceinc "anymagic not nature *0"
+#chanceinc "primaryrace vaettir 0.45"
+#command "#gcost +30"
+#command "#templetrainer 1309"
+#notfortier 1
+#notfortier 3
+#description " Can train sacred wolves in temples."
+#theme "wolftotem"
+#theme "totemanimal"
+#end
+
+#new magefilter
+#name "bear trainer"
+#type "leadership"
+#basechance 0.05
+#chanceinc "nationtag boreal OR nationtag nordic 0.45"
+#chanceinc "racetheme totemanimal OR unittheme totemanimal AND racetheme NOT beartotem AND unittheme NOT beartotem *0"
+#chanceinc "anymagic not nature *0"
+#command "#gcost +30"
+#command "#templetrainer 3003"
+#notfortier 1
+#notfortier 3
+#description " Can train sacred bears in temples."
+#theme "beartotem"
+#theme "totemanimal"
+#end
+
+#new magefilter
+#name "boar trainer"
+#type "leadership"
+#basechance 0.05
+#chanceinc "nationtag boreal 0.95"
+#chanceinc "racetheme totemanimal OR unittheme totemanimal AND racetheme NOT boartotem AND unittheme NOT boartotem *0"
+#chanceinc "anymagic not nature *0"
+#chanceinc "primaryrace hoburg 0.25"
+#command "#gcost +20"
+#command "#templetrainer 1807"
+#notfortier 1
+#notfortier 3
+#description " Can train sacred boars in temples."
+#theme "boartotem"
+#theme "totemanimal"
+#end
+
+#new magefilter
+#name "scorpion trainer"
+#type "leadership"
+#basechance 0.05
+#chanceinc "nationtag occidental 0.45"
+#chanceinc "racetheme totemanimal OR unittheme totemanimal AND racetheme NOT scorpiontotem AND unittheme NOT scorpiontotem *0"
+#chanceinc "anymagic not earth *0"
+#chanceinc "primaryrace zotz 0.5"
+#chanceinc "primaryrace Abysian 0.25"
+#command "#gcost +40"
+#command "#templetrainer 2690"
+#notfortier 1
+#notfortier 3
+#description " Can train sacred scorpions in temples."
+#theme "scopriontotem"
+#theme "totemanimal"
+#end
+
+#new magefilter
+#name "scorpion trainer"
+#type "leadership"
+#basechance 0.05
+#chanceinc "nationtag occidental 0.45"
+#chanceinc "racetheme totemanimal OR unittheme totemanimal AND racetheme NOT scorpiontotem AND unittheme NOT scorpiontotem *0"
+#chanceinc "primaryrace 'Dynastic human' 0.25"
+#chanceinc "anymagic not earth *0"
+#chanceinc "primaryrace zotz 0.5"
+#chanceinc "primaryrace Abysian 0.25"
+#command "#gcost +40"
+#command "#templetrainer 2690"
+#notfortier 1
+#notfortier 3
+#description " Can train sacred scorpions in temples."
+#theme "scopriontotem"
+#theme "totemanimal"
+#end
+
+#new magefilter
+#name "condor trainer"
+#type "leadership"
+#basechance 0.05
+#chanceinc "nationtag occidental 0.95"
+#chanceinc "racetheme totemanimal OR unittheme totemanimal AND racetheme NOT birdtotem AND unittheme NOT birdtotem *0"
+#chanceinc "anymagic not air *0"
+#chanceinc "primaryrace Caelian 0.25"
+#command "#gcost +20"
+#command "#templetrainer 2694"
+#notfortier 1
+#notfortier 3
+#description " Can train sacred condors in temples."
+#theme "condortotem"
+#theme "totemanimal"
+#end
+
+#new magefilter
+#name "gloso trainer"
+#type "leadership"
+#basechance 0.05
+#chanceinc "nationtag nordic 0.45"
+#chanceinc "nationtag boreal 0.05"
+#chanceinc "racetheme totemanimal OR unittheme totemanimal AND racetheme NOT boartotem AND unittheme NOT boartotem *0"
+#chanceinc "primaryrace Abysian 0.45"
+#chanceinc "primaryrace hoburg 0.20"
+#chanceinc "anymagic not death *0"
+#command "#gcost +30"
+#command "#templetrainer 2363"
+#notfortier 1
+#notfortier 3
+#description " Can train sacred black sows in temples."
+#theme "boartotem"
+#theme "totemanimal"
+#end
+
+#new magefilter
+#name "iron pig trainer"
+#type "leadership"
+#basechance 0
+#chanceinc "primaryrace hoburg 0.25"
+#chanceinc "racetheme industrial 0.25"
+#chanceinc "racetheme feral OR racetheme agrarian OR racetheme fae *0"
+#chanceinc "racetheme lesser_golem_cult 0.25"
+#chanceinc "racetheme greater_golem_cult 0.5"
+#command "#gcost +30"
+#command "#templetrainer 1808"
+#notfortier 1
+#notfortier 3
+#description " Can rivet metal plates onto blessed hogs in temples."
+#theme "boartotem"
+#theme "totemanimal"
+#end
+
+#new magefilter
+#name "seelie dog trainer"
+#type "leadership"
+#basechance 0
+#chanceinc "nationtag boreal 0.05"
+#chanceinc "#chanceinc nationtag fae OR hasthemetheme fae 0.25"
+#chanceinc "primaryrace Sidhe 0.25"
+#chanceinc "primaryrace 'Fir Bolg' 0.1"
+#chanceinc "magic not nature *0"
+#command "#gcost +30"
+#command "#templetrainer 1770"
+#notfortier 1
+#notfortier 3
+#description " Can train sacred fae hounds in temples."
+#theme "fae"
+#theme "nature"
+#end
+
+#new magefilter
+#name "unseelie dog trainer"
+#type "leadership"
+#basechance 0
+#chanceinc "nationtag boreal 0.05"
+#chanceinc "#chanceinc nationtag fae OR hasthemetheme fae 0.25"
+#chanceinc "primaryrace Sidhe OR primaryrace Fomorian 0.25"
+#chanceinc "primaryrace 'Fir Bolg' 0.1"
+#chanceinc "magic not death *0"
+#command "#gcost +30"
+#command "#templetrainer 1768"
+#notfortier 1
+#notfortier 3
+#description " Can train sacred fae hounds in temples."
+#theme "fae"
+#theme "death"
+#end
+
+#new magefilter
+#name "teacher of Truths"
+#type "leadership"
+#basechance 0
+#chanceinc "primaryrace Primate AND hasthemetheme lowland AND hasthemetheme enlightened 0.25"
+#chanceinc "magic not astral AND magic not nature OR anymagic blood *0"
+#command "#gcost +30"
+#command "#templetrainer 2271"
+#notfortier 1
+#notfortier 3
+#description " Can teach pious ascetics in temples."
+#theme "enlightened"
+#end
+
+#new magefilter
+#name "Smoulderghost caller"
+#type "leadership"
+#basechance 0
+#chanceinc "nationtag abysian OR hasthemetheme abysian 0.1"
+#chanceinc "magic not death *0"
+#chanceinc "primaryrace Abysian AND anymagic death 0.25"
+#command "#gcost +30"
+#command "#undeadcommand 10"
+#command "#templetrainer 1971"
+#notfortier 1
+#notfortier 3
+#description " Can recall sacred Lavaborn ancestors in temples."
+#theme "abysian"
+#theme "death"
+#end
+
+#new magefilter
+#name "statue sculptor"
+#type "leadership"
+#basechance 0
+#chanceinc "primaryrace "Boreal human" OR primaryrace "Advanced human" OR primaryrace "Oriental human" AND magic earth 0.25"
+#chanceinc "primaryrace "Imperial human" OR primaryrace "Austral human" OR primaryrace "Amazon human" AND magic earth 0.1"
+#chanceinc "nationcommand golemhp above 4 *2"
+#chanceinc "nationcommand golemhp above 9 *2"
+#command "#gcost +10"
+#command "#magiccommand 10"
+#command "#templetrainer 1497"
+#notfortier 1
+#notfortier 3
+#description " Can sculpt animate statues in temples."
+#theme "human"
+#theme "earth"
+#theme "golem"
+#end
+
+#new magefilter
+#name "large statue sculptor"
+#type "leadership"
+#basechance 0
+#chanceinc "primaryrace "Imperial human" OR primaryrace "Austral human" OR primaryrace "Amazon human" AND magic earth 0.25"
+#chanceinc "primaryrace "Boreal human" OR primaryrace "Advanced human" OR primaryrace "Oriental human" AND magic earth 0.1"
+#chanceinc "nationcommand golemhp above 4 *2"
+#chanceinc "nationcommand golemhp above 9 *2"
+#command "#gcost +10"
+#command "#magiccommand 10"
+#command "#templetrainer 474"
+#notfortier 1
+#notfortier 3
+#description " Can sculpt large animate statues in temples."
+#theme "human"
+#theme "earth"
+#theme "golem"
+#end
+
+#new magefilter
+#name "Sentinel sculptor"
+#type "leadership"
+#basechance 0
+#chanceinc "primaryrace Agarthan AND magic earth AND hasthemetheme not nadir 0.25"
+#chanceinc "hasthemetheme waxing -0.15"
+#chanceinc "nationcommand golemhp above 4 *2"
+#chanceinc "nationcommand golemhp above 9 *2"
+#command "#gcost +30"
+#command "#magiccommand 10"
+#command "#templetrainer 1496"
+#notfortier 1
+#notfortier 3
+#description " Can sculpt sacred statues in temples."
+#theme "agarthan"
+#theme "earth"
+#theme "golem"
+#end

--- a/data/items/highmen/cavemen/armor.txt
+++ b/data/items/highmen/cavemen/armor.txt
@@ -50,6 +50,7 @@
 #armor
 #basechance 0.2
 #theme "primitive"
+#theme "beartotem"
 #tag "bear"
 #enditem
 
@@ -62,6 +63,7 @@
 #armor
 #basechance 0.2
 #theme "primitive"
+#theme "liontotem"
 #tag "lion"
 #enditem
 
@@ -74,6 +76,7 @@
 #armor
 #basechance 0.2
 #theme "primitive"
+#theme "wolftotem"
 #tag "wolf"
 #enditem
 
@@ -86,6 +89,7 @@
 #armor
 #basechance 0.2
 #theme "primitive"
+#theme "boartotem"
 #tag "boar"
 #enditem
 
@@ -100,6 +104,7 @@
 #basechance 0.05
 #theme "primitive"
 #theme "fire"
+#theme "draketotem"
 #tag "drake"
 #enditem
 
@@ -114,6 +119,7 @@
 #basechance 0.05
 #theme "primitive"
 #theme "water"
+#theme "draketotem"
 #tag "drake"
 #enditem
 
@@ -128,6 +134,7 @@
 #basechance 0.05
 #theme "primitive"
 #theme "nature"
+#theme "draketotem"
 #tag "drake"
 #enditem
 
@@ -142,6 +149,7 @@
 #basechance 0.05
 #theme "primitive"
 #theme "earth"
+#theme "draketotem"
 #tag "drake"
 #enditem
 

--- a/data/items/hoburg/clockwork/armor_clockwork_colossal.txt
+++ b/data/items/hoburg/clockwork/armor_clockwork_colossal.txt
@@ -28,7 +28,7 @@
 #define "#poisonres +25"
 #define "#slashres"
 #define "#pierceres"
-#define "#woundfend 75"
+#define "#woundfend +4"
 #define "#inspirational +1"
 #define "#mounted"
 #define "#trample"

--- a/data/items/hoburg/clockwork/armor_clockwork_heavy.txt
+++ b/data/items/hoburg/clockwork/armor_clockwork_heavy.txt
@@ -28,7 +28,7 @@
 #define "#poisonres +10"
 #define "#slashres"
 #define "#pierceres"
-#define "#woundfend 75"
+#define "#woundfend +3"
 #define "#mounted"
 #define "#nomovepen"
 #define "#humanoid"

--- a/data/items/hoburg/clockwork/armor_clockwork_light.txt
+++ b/data/items/hoburg/clockwork/armor_clockwork_light.txt
@@ -21,7 +21,7 @@
 #define "#mapmove 18"
 #define "#ap +8"
 #define "#mounted"
-#define "#woundfend 25"
+#define "#woundfend +1"
 #description "Their armor is driven by complex clockwork mechanisms that increase their strength and speed, but run down and need rewound"
 #define "#nomovepen"
 #define "#humanoid"

--- a/data/items/hoburg/clockwork/armor_clockwork_medium.txt
+++ b/data/items/hoburg/clockwork/armor_clockwork_medium.txt
@@ -26,7 +26,7 @@
 #define "#shockres +5"
 #define "#poisonres +5"
 #define "#slashres"
-#define "#woundfend 50"
+#define "#woundfend +2"
 #define "#mounted"
 #description "Their heavy armor is driven by complex clockwork mechanisms that increase their strength and speed, but gradually run down and need rewound"
 #define "#nomovepen"

--- a/data/items/hoburg/clockwork/bronze/armor_clockwork_colossal.txt
+++ b/data/items/hoburg/clockwork/bronze/armor_clockwork_colossal.txt
@@ -28,7 +28,7 @@
 #define "#poisonres +25"
 #define "#slashres"
 #define "#pierceres"
-#define "#woundfend 75"
+#define "#woundfend +4"
 #define "#inspirational +1"
 #define "#mounted"
 #define "#trample"

--- a/data/items/hoburg/clockwork/bronze/armor_clockwork_heavy.txt
+++ b/data/items/hoburg/clockwork/bronze/armor_clockwork_heavy.txt
@@ -28,7 +28,7 @@
 #define "#poisonres +10"
 #define "#slashres"
 #define "#pierceres"
-#define "#woundfend 75"
+#define "#woundfend +3"
 #define "#mounted"
 #define "#nomovepen"
 #define "#humanoid"

--- a/data/items/hoburg/clockwork/bronze/armor_clockwork_light.txt
+++ b/data/items/hoburg/clockwork/bronze/armor_clockwork_light.txt
@@ -20,7 +20,7 @@
 #define "#mapmove 18"
 #define "#ap +8"
 #define "#mounted"
-#define "#woundfend 25"
+#define "#woundfend +1"
 #description "Their armor is driven by complex clockwork mechanisms that increase their strength and speed, but run down and need rewound"
 #define "#nomovepen"
 #define "#humanoid"

--- a/data/items/hoburg/clockwork/bronze/armor_clockwork_medium.txt
+++ b/data/items/hoburg/clockwork/bronze/armor_clockwork_medium.txt
@@ -25,7 +25,7 @@
 #define "#shockres +5"
 #define "#poisonres +5"
 #define "#slashres"
-#define "#woundfend 50"
+#define "#woundfend +2"
 #define "#mounted"
 #define "#nomovepen"
 #define "#humanoid"

--- a/data/items/hoburg/clockwork/oriental/armor_clockwork_colossal.txt
+++ b/data/items/hoburg/clockwork/oriental/armor_clockwork_colossal.txt
@@ -28,7 +28,7 @@
 #define "#poisonres +25"
 #define "#slashres"
 #define "#pierceres"
-#define "#woundfend 75"
+#define "#woundfend +4"
 #define "#inspirational +1"
 #define "#mounted"
 #define "#trample"

--- a/data/items/hoburg/clockwork/oriental/armor_clockwork_heavy.txt
+++ b/data/items/hoburg/clockwork/oriental/armor_clockwork_heavy.txt
@@ -29,7 +29,7 @@
 #define "#poisonres +10"
 #define "#slashres"
 #define "#pierceres"
-#define "#woundfend 75"
+#define "#woundfend +3"
 #define "#mounted"
 #define "#nomovepen"
 #define "#humanoid"

--- a/data/items/hoburg/clockwork/oriental/armor_clockwork_light.txt
+++ b/data/items/hoburg/clockwork/oriental/armor_clockwork_light.txt
@@ -22,7 +22,7 @@
 #define "#mapmove 18"
 #define "#ap +8"
 #define "#mounted"
-#define "#woundfend 25"
+#define "#woundfend +1"
 #description "Their armor is driven by complex clockwork mechanisms that increase their strength and speed, but run down and need rewound"
 #define "#nomovepen"
 #define "#humanoid"
@@ -54,7 +54,7 @@
 #define "#mapmove 2"
 #define "#ap +8"
 #define "#mounted"
-#define "#woundfend 25"
+#define "#woundfend +1"
 #description "Their armor is driven by complex clockwork mechanisms that increase their strength and speed, but run down and need rewound"
 #define "#itemslots 12422"
 

--- a/data/items/hoburg/clockwork/oriental/armor_clockwork_medium.txt
+++ b/data/items/hoburg/clockwork/oriental/armor_clockwork_medium.txt
@@ -27,7 +27,7 @@
 #define "#shockres +5"
 #define "#poisonres +5"
 #define "#slashres"
-#define "#woundfend 50"
+#define "#woundfend +2"
 #define "#mounted"
 #define "#nomovepen"
 #define "#humanoid"

--- a/data/items/hoburg/vines/armor_parasite.txt
+++ b/data/items/hoburg/vines/armor_parasite.txt
@@ -24,7 +24,7 @@
 #define "#prec *0.5"
 #define "#supplybonus *0"
 #define "#poisonres +15"
-#define "#woundfend 50"
+#define "#woundfend +2"
 #define "#mounted"
 #define "#forestsurvival"
 #define "#neednoteat"

--- a/data/items/hoburg/vines/armor_symbiote.txt
+++ b/data/items/hoburg/vines/armor_symbiote.txt
@@ -25,7 +25,7 @@
 #define "#supplybonus *0"
 #define "#poisonres +10"
 #define "#bluntres"
-#define "#woundfend 50"
+#define "#woundfend +2"
 #define "#mounted"
 #define "#forestsurvival"
 #define "#neednoteat"

--- a/data/items/human/scout/weapon.txt
+++ b/data/items/human/scout/weapon.txt
@@ -110,7 +110,7 @@
 
 #newitem
 #id mace
-#gameid 8
+#gameid 12
 #sprite /graphics/scouts/weapon/mace.png
 #theme "iron"
 #theme "austral"

--- a/data/items/sidhe/bases.txt
+++ b/data/items/sidhe/bases.txt
@@ -15,6 +15,7 @@
 #define "#prec 12"
 #define "#darkvision 50"
 #define "#illusion"
+#define "#spellsinger"
 -- #define "#stealthy 0" -- granted by poses so chariots aren't stealthy
 #define "#maxage 1000"
 #define "#forestsurvival"

--- a/data/items/sidhe/bean/bases.txt
+++ b/data/items/sidhe/bean/bases.txt
@@ -16,6 +16,7 @@
 #define "#prec 12"
 #define "#darkvision 50"
 #define "#illusion"
+#define "#spellsinger"
 -- #define "#stealthy 0" -- granted by poses so chariots aren't stealthy
 #define "#maxage 1000"
 #define "#forestsurvival"

--- a/data/items/sidhe/bean/bases_mounted.txt
+++ b/data/items/sidhe/bean/bases_mounted.txt
@@ -16,6 +16,7 @@
 #define "#prec 12"
 #define "#darkvision 50"
 #define "#illusion"
+#define "#spellsinger"
 -- #define "#stealthy 0" -- granted by poses so chariots aren't stealthy
 #define "#maxage 1000"
 #define "#forestsurvival"

--- a/data/races/lizards.txt
+++ b/data/races/lizards.txt
@@ -72,5 +72,6 @@
 #chanceinc race "Dynastic human" *3"
 
 #dynastic
+#serpent
 
 #endrace

--- a/data/races/nagas.txt
+++ b/data/races/nagas.txt
@@ -11,6 +11,7 @@
 #enlightened
 #subterranean
 #amphibian
+#serpent
 
 #magepriestchance 0.4
 

--- a/data/races/serpentmen.txt
+++ b/data/races/serpentmen.txt
@@ -7,6 +7,8 @@
 #freetheme demographic
 #freetheme regional
 
+#serpent
+
 #pose serpenttroops
 #pose serpentmages
 

--- a/data/spells/custom_spells.txt
+++ b/data/spells/custom_spells.txt
@@ -42,3 +42,43 @@
 #command "#nreff 4038"
 #command "#descr 'The cycle of life is accelerated among the residents of the province. As a result, many simple-minded but loyal Foul Spawn will be born and grow to maturity in the span of a month. With luck, some may even grow well beyond their natural size.'"
 #end
+
+--- Fae summons
+#new
+#name "Contact Bean Sidhe"
+#command "#copyspell 'Summon Bean Sidhe'"
+#command "#name 'Contact Bean Sidhe'"
+#command "#path 0 6"
+#command "#path 1 -1"
+#command "#pathlevel 0 1"
+#command "#descr 'The caster summons a reclusive Sidhe woman from the wilderness where she practices her arts. These sorceresses rarely join or lead armies, but are skilled in the crafts, poetry and magic of the Sidhe.'"
+#end
+
+#new
+#name "Contact Baobhan Sidhe"
+#command "#copyspell 'Summon Bean Sidhe'"
+#command "#name 'Contact Baobhan Sidhe'"
+#command "#path 0 1"
+#command "#path 1 -1"
+#command "#pathlevel 0 1"
+#command "#descr 'The caster summons a Sidhe descendant of the Morrigans. Baobhan Sidhe are seductresses and blood drinkers who haunt the wilderness in the form of stunningly beautiful maidens and lure humans to their deadly embrace.'"
+#end
+
+--- Death mirrors of Nature Choruses
+#new
+#name "Dirge Master"
+#command "#copyspell 'Chorus Master'"
+#command "#name 'Dirge Master'"
+#command "#path 0 5"
+#command "#path 1 -1"
+#command "#pathlevel 0 1"
+#end
+
+#new
+#name "Dirge Slave"
+#command "#copyspell 'Chorus Master'"
+#command "#name 'Dirge Slave'"
+#command "#path 0 5"
+#command "#path 1 -1"
+#command "#pathlevel 0 1"
+#end

--- a/data/spells/guaranteed_spells.txt
+++ b/data/spells/guaranteed_spells.txt
@@ -266,7 +266,7 @@
 #chanceinc primaryrace not "Pale one" *0
 #end
 
-- Monkey blood spells
+- Enlightened blood spells
 - Way more likely with blood access
 ----------------------
 #new
@@ -283,7 +283,8 @@
 #spell "Host of Ganas"
 #spell "Summon Vetalas"
 #basechance 0
-#chanceinc primaryrace "Primate" 1
+#chanceinc nationtag enlightened 1 
+#chanceinc hasthemetheme enlightened 1
 #chanceinc anymagic not blood *0.5
 #chanceinc random 0.5 -0.66
 #chanceinc random 0.33 *0
@@ -319,4 +320,65 @@
 #chanceinc primaryrace "Ichtyid" 1
 #chanceinc random 0.125 *0
 #chanceinc anymagic not water *0
+#end
+
+- Fae spells
+------------------------
+#new
+#name "Fae spells - Nature"
+#spell "Contact Cu Sidhe"
+#spell "Contact Bean Sidhe"
+#basechance 0
+#chanceinc primaryrace "Sidhe" 1
+#chanceinc nationtag fae 1
+#chanceinc hasthemetheme fae 1
+#chanceinc random 0.25 *0
+#chanceinc anymagic not nature *0
+#end
+
+#new
+#name "Fae spells - Air"
+#spell "Contact Baobhan Sidhe"
+#spell "Summon Morrigan"
+#spell "Dance of the Morrigans"
+#basechance 0
+#chanceinc primaryrace "Sidhe" 1
+#chanceinc nationtag fae 1
+#chanceinc hasthemetheme fae 1
+#chanceinc random 0.25 *0
+#chanceinc anymagic not air *0
+#chanceinc anymagic not death AND random 0.5 *0
+#end
+
+#new
+#name "Fae spells - Death"
+#spell "Summon Black Dogs"
+#spell "Summon Barghests"
+#spell "Summon Bean Sidhe"
+#basechance 0
+#chanceinc primaryrace "Sidhe" 1
+#chanceinc nationtag fae 1
+#chanceinc hasthemetheme fae 1
+#chanceinc random 0.25 *0
+#chanceinc anymagic not death *0
+#end
+
+#new
+#name "Communion Choruses - nature"
+#spell "Chorus Master"
+#spell "Chorus Slave"
+#basechance 0
+#chanceinc command "#spellsinger" 1
+#chanceinc primaryrace "Sidhe" AND random 0.5 OR random 0.5 *0
+#chanceinc magic not nature *0
+#end
+
+#new
+#name "Communion Choruses - death"
+#spell "Dirge Master"
+#spell "Dirge Slave"
+#basechance 0
+#chanceinc command "#spellsinger" 1
+#chanceinc primaryrace "Sidhe" AND random 0.5 OR random 0.5 *0
+#chanceinc magic not death *0
 #end

--- a/data/themes/boreal_themes.txt
+++ b/data/themes/boreal_themes.txt
@@ -58,7 +58,7 @@
 #newtheme
 #type social
 #name slaver
-#basechance 0.1
+#basechance 0.2
 #themeinc theme advanced *1
 #themeinc theme iron *1
 #themeinc theme bronze *1
@@ -80,28 +80,90 @@
 #racedefinition "#secondaryracemagemod -100"
 #endtheme
 
--- Weights: EA 0.05, MA 0.1, LA 0.2
+-- Weights: EA 0.1, MA 0.2, LA 0.3
 #newtheme
 #type social
 #name blacksteel
-#basechance 0.1
-#chanceinc era 1 0.5
-#chanceinc era 3 2
+#basechance 0.2
+#chanceinc era 1 -0.1
+#chanceinc era 3 0.1
 #chanceinc racetheme primitive *0.5
 #chanceinc racetheme bronze *0.125
 #chanceinc racetheme default *1
 #chanceinc racetheme advanced *2
 #themeinc theme advanced *2
 #themeinc theme iron *5
-#chanceinc racetheme bronze *0.125
+#themeinc theme bronze *0.125
 #themeinc theme wood *0.5
 #themeinc theme leather *0.25
 #themeinc theme naked *0.125
 #themeinc theme primitive *0.5
 #racedefinition "#pose blacksteeltroops"
 #racedefinition "#magicpriority earth 3"
-#racedefinition "#unitcommand '#hp +2'
-#racedefinition "#unitcommand '#str +1'
-#racedefinition "#unitcommand '#mr -2'
-#racedefinition "#unitcommand '#enc -1'
+#racedefinition "#unitcommand '#hp +2'"
+#racedefinition "#unitcommand '#str +1'"
+#racedefinition "#unitcommand '#mr -2'"
+#racedefinition "#unitcommand '#enc -1'"
+#racedefinition "#unitcommand '#nametype 104'"
+#endtheme
+
+-- Weights: EA 0.1, MA 0.05, LA 0
+#newtheme
+#type social
+#name fae_seelie
+#basechance 0.1
+#chanceinc era 2 -0.05
+#chanceinc era 3 -0.1
+#chanceinc racetheme primitive *2
+#chanceinc racetheme bronze *3
+#chanceinc racetheme default *0.5
+#chanceinc racetheme advanced *0
+#themeinc theme advanced *0.125
+#themeinc theme iron *0.25
+#themeinc theme bronze *2
+#themeinc theme wood *2
+#themeinc theme leather *2
+#themeinc theme naked *1
+#themeinc theme primitive *1
+#racedefinition "#fae"
+#racedefinition "#magicpriority nature 4"
+#racedefinition "#unitcommand '#mr +1'"
+#racedefinition "#unitcommand '#spellsinger'"
+#racedefinition "#unitcommand '#nametype 142'"
+#endtheme
+
+-- Weights: EA 0.1, MA 0.05, LA 0
+#newtheme
+#type social
+#name fae_unseelie
+#basechance 0.1
+#chanceinc era 2 -0.05
+#chanceinc era 3 -0.1
+#chanceinc racetheme primitive *2
+#chanceinc racetheme bronze *3
+#chanceinc racetheme default *0.5
+#chanceinc racetheme advanced *0
+#themeinc theme advanced *0.125
+#themeinc theme iron *0.5
+#themeinc theme bronze *2
+#themeinc theme wood *2
+#themeinc theme leather *2
+#themeinc theme naked *1
+#themeinc theme primitive *1
+#racedefinition "#fae"
+#racedefinition "#magicpriority death 4"
+#racedefinition "#magicpriority nature 2"
+#racedefinition "#unitcommand '#mr +1'"
+#racedefinition "#unitcommand '#spellsinger'"
+#racedefinition "#unitcommand '#nametype 142'"
+#endtheme
+
+-- Weights: EA 0.1, MA 0.1, LA 0.1
+#newtheme
+#type social
+#name spellsingers
+#basechance 0.1
+#racedefinition "#magicpriority death 2"
+#racedefinition "#magicpriority nature 2"
+#racedefinition "#unitcommand '#spellsinger'"
 #endtheme

--- a/data/themes/default_nationthemes.txt
+++ b/data/themes/default_nationthemes.txt
@@ -122,8 +122,6 @@
 - Dominion effects
 -----------
 
-
-
 #new
 #name "nopreach"
 #type "bloodsac"
@@ -201,6 +199,24 @@
 #desc "Priests can incite the nature to reanimate dead bodies to fight again. This causes some unrest amongst the population."
 #magepriestchance 0.85
 #priestextracost 30
+#end
+
+#new
+#name "golemcult_5"
+#type "dominion"
+#basechance 0.06
+#command "#golemhp 5"
+#magicpriority earth 4
+#desc "Inanimate creations are stronger in this dominion"
+#end
+
+#new
+#name "golemcult_10"
+#type "dominion"
+#basechance 0.03
+#command "#golemhp 10"
+#magicpriority earth 10
+#desc "Inanimate creations are much stronger in this dominion"
 #end
 
 #new

--- a/data/themes/hoburg_themes.txt
+++ b/data/themes/hoburg_themes.txt
@@ -418,6 +418,7 @@
 #racedefinition "#unitcommand '#darkvision 50'"
 #racedefinition "#unitcommand '#forestsurvival'"
 #racedefinition "#unitcommand '#illusion'"
+#racedefinition "#unitcommand '#spellsinger'"
 #racedefinition "#unitcommand '#nametype 142'"
 #endtheme
 

--- a/documentation/special_commands.txt
+++ b/documentation/special_commands.txt
@@ -343,7 +343,7 @@ Mage variants vary one of the slots defined by the #varyslot command. Overrides 
 This pose will not be eligible for selection as a secondary race pose
 
 #cannot_be_commander
-This pose will not be eligible for selection as a commander if at all possible
+This pose will not be eligible for selection as a commander if at all possible (e.g., gladiators)
 
 #should_be_commander
 This pose will be given priority for selection as a commander

--- a/settings.txt
+++ b/settings.txt
@@ -21,7 +21,7 @@ maxrestrictedperspell 8
 -------------- Generic generation stuff
 
 -- Era, 1 is early, 2 is middle, 3 is late obviously
-era 1.0
+era 2.0
 
 -- Sacred power. 1-3. Normal = 1, High = 2, Batshit Insane = 3
 sacredpower 1.0

--- a/settings.txt
+++ b/settings.txt
@@ -21,7 +21,7 @@ maxrestrictedperspell 8
 -------------- Generic generation stuff
 
 -- Era, 1 is early, 2 is middle, 3 is late obviously
-era 2.0
+era 1.0
 
 -- Sacred power. 1-3. Normal = 1, High = 2, Batshit Insane = 3
 sacredpower 1.0


### PR DESCRIPTION
* Sidhe, priest-mage elegists, fae-themed nations, some boreal nations, and some rando mages are spellsingers
* Spellsinging choruses (nature) and spellsinging dirges (death) are possible for nations with spellsingers
* A LOT of templetrainer commands added; right now since I'm too lazy to update second shape handling to accomadate arbitrary #templetrainer <fooshape>, it's only using vanilla sacred units that I can directly reference by #id. I've restricted #templetrainer to H2, and for units w/o an upkeep (i.e., most of the ones I used) the command adds 20-40g to the trainer's cost.
* #woundfend updated to Dom5 standards, so it will no longer always mean "you don't take wounds lol"