### PR TITLE
Contact Foo Sidhe fixes

### DIFF
--- a/data/spells/custom_spells.txt
+++ b/data/spells/custom_spells.txt
@@ -65,7 +65,8 @@
 #command "#path 0 6"
 #command "#path 1 -1"
 #command "#pathlevel 0 1"
-#command "#descr 'The caster summons a reclusive Sidhe woman from the wilderness where she practices her arts. These sorceresses rarely join or lead armies, but are skilled in the crafts, poetry and magic of the Sidhe.'"
+#command "#damage 1774"
+#command "#descr 'The caster contacts a reclusive Sidhe woman from the wilderness and extracts an oath of servitude in exchange for gems and gold. These sorceresses rarely join or lead armies, but are skilled in the crafts, poetry and magic of the Sidhe.'"
 #end
 
 #new
@@ -75,7 +76,8 @@
 #command "#path 0 1"
 #command "#path 1 -1"
 #command "#pathlevel 0 1"
-#command "#descr 'The caster summons a Sidhe descendant of the Morrigans. Baobhan Sidhe are seductresses and blood drinkers who haunt the wilderness in the form of stunningly beautiful maidens and lure humans to their deadly embrace.'"
+#command "#damage 1775"
+#command "#descr 'The caster contacts a Sidhe descendant of the Morrigans and extracts an oath of servitude in exchange for gems and gold. Baobhan Sidhe are seductresses and blood drinkers who haunt the wilderness in the form of stunningly beautiful maidens and lure humans to their deadly embrace.'"
 #end
 
 --- Death mirrors of Nature Choruses


### PR DESCRIPTION
* Contact spells to summon living sidhe sorceresses fixed so they no longer summon undead Bean Sidhe regardless of the spell cast.
* Changed Contact Foo Sidhe spell descriptions to make it more clear that these summon mages with upkeep