### PR TITLE
Removing diacritics in Nordic nation names

### DIFF
--- a/data/names/nations/nordic/longsyllables.txt
+++ b/data/names/nations/nordic/longsyllables.txt
@@ -1,4 +1,4 @@
-aling
+﻿aling
 ar
 bo
 boll
@@ -15,18 +15,18 @@ fager
 falken
 van
 mar
-öre
-öst
+ore
+ost
 vax
 norr
 y
-ö
-väster
+o
+vaster
 sand
 kal
 lu
 lu
-väs
+vas
 bus
 opp
 hed
@@ -36,7 +36,7 @@ nar
 far
 dra
 berg
-åle
+ale
 bre
 kirk
 leir
@@ -44,6 +44,6 @@ lek
 kram
 kors
 ny
-när
+nar
 salt
-vår
+var

--- a/data/names/nations/nordic/shortsyllables.txt
+++ b/data/names/nations/nordic/shortsyllables.txt
@@ -1,7 +1,7 @@
-ke "cantbeafter consonant"
+﻿ke "cantbeafter consonant"
 van
 mun
-ö "cantbeafter ö"
+o "cantbeafter o"
 kul
 mar
 s "cantbeafter s"

--- a/data/names/nations/nordic/suffixes.txt
+++ b/data/names/nations/nordic/suffixes.txt
@@ -1,4 +1,4 @@
-heim
+﻿heim
 heim
 heim
 rus
@@ -23,7 +23,7 @@ hamn
 nes
 ping
 land
-hälla
+halla
 fors
 strand
 mark


### PR DESCRIPTION
* Dominions is Nagot gic fel-ing when Nordic nations have diacritics in their names, so all name parts with letters featuring diacritics have had the letters replaced with uninflected versions of the same letter