### PR TITLE
Missing slot fixes

### DIFF
--- a/data/items/atlantian/standard-s.txt
+++ b/data/items/atlantian/standard-s.txt
@@ -11,5 +11,6 @@
 #tag "noelite"
 #tag "noslot offhand"
 #tag "cannot_be_pd"
+#tag "cannot_be_commander"
 #define "#aisinglerec"
 #enditem

--- a/data/items/atlantian/standard.txt
+++ b/data/items/atlantian/standard.txt
@@ -11,5 +11,6 @@
 #tag "noelite"
 #tag "noslot offhand"
 #tag "cannot_be_pd"
+#tag "cannot_be_commander"
 #define "#aisinglerec"
 #enditem

--- a/data/poses/atlantian/infantry.txt
+++ b/data/poses/atlantian/infantry.txt
@@ -9,7 +9,7 @@
 #load armor /data/items/atlantian/naked.txt
 #load helmet /data/items/atlantian/helmet.txt
 #load legs /data/items/atlantian/legs.txt
-#load standard /data/items/atlantian/standard.txt
+#load weapon /data/items/atlantian/standard.txt
 #load weapon /data/items/atlantian/weapon.txt
 #load offhand /data/items/atlantian/shield.txt
 #load bonusweapon /data/items/atlantian/bonusrangedweapon.txt
@@ -30,7 +30,7 @@
 #load armor /data/items/atlantian/naked.txt
 #load helmet /data/items/atlantian/icehelmet.txt
 #load legs /data/items/atlantian/legs.txt
-#load standard /data/items/atlantian/standard.txt
+#load weapon /data/items/atlantian/standard.txt
 #load weapon /data/items/atlantian/iceweapon.txt
 #load offhand /data/items/atlantian/iceshield.txt
 #load offhand /data/items/atlantian/shield.txt
@@ -48,7 +48,6 @@
 #load basesprite /data/items/atlantian/atlantianbases.txt
 #load shadow /data/items/atlantian/shadow.txt
 #load armor /data/items/atlantian/meteorarmor.txt
--- #load armor /data/items/atlantian/naked.txt
 #load helmet /data/items/atlantian/helmet.txt
 #load legs /data/items/atlantian/legs.txt
 #load weapon /data/items/atlantian/meteorweapon.txt
@@ -141,10 +140,11 @@
 #load legs /data/items/atlantian/shamblerlegs.txt
 #load helmet /data/items/atlantian/shamblerhelmet.txt
 #load weapon /data/items/atlantian/shamblerweapon.txt
-#load weapon2 /data/items/atlantian/lobsterweapon.txt
+#load weapon /data/items/atlantian/lobsterweapon.txt
+#load weapon /data/items/atlantian/standard-s.txt
 #load bonusweapon /data/items/atlantian/bonusrangedweapon-s.txt
 #load offhand /data/items/atlantian/shamblershield.txt
-#load standard /data/items/atlantian/standard-s.txt
+
 
 #command "#amphibian"
 #good_leader

--- a/data/poses/highmen/cavemanallies.txt
+++ b/data/poses/highmen/cavemanallies.txt
@@ -89,7 +89,7 @@
 #command "#mountainsurvival"
 #command "#maxage 50"
 
-#renderorder "shadow bonusweapon cloakb basesprite armor cloakf weapon offhand hands hair helmet"
+#renderorder "shadow bonusweapon cloakb basesprite shirt armor cloakf weapon offhand hands hair helmet"
 
 #load basesprite /data/items/highmen/cavemen/bases.txt
 #load shadow /data/items/highmen/cavemen/shadow.txt

--- a/data/poses/highmen/cavemanmages.txt
+++ b/data/poses/highmen/cavemanmages.txt
@@ -5,7 +5,7 @@
 #role "mage"
 #role "priest"
 
-#renderorder "shadow bonusweapon cloakb basesprite armor cloakf weapon offhand hands hair helmet"
+#renderorder "shadow bonusweapon cloakb basesprite shirt armor cloakf weapon offhand hands hair helmet"
 
 #load basesprite /data/items/highmen/cavemen/bases.txt
 #load shadow /data/items/highmen/cavemen/shadow.txt

--- a/data/poses/imperial/sacred.txt
+++ b/data/poses/imperial/sacred.txt
@@ -14,7 +14,7 @@
 #command "#att +1"
 #command "#def +1"
 
-#renderorder "shadow cloakb bonusweapon basesprite shirt armor weapon offhandw hands helmet offhanda"
+#renderorder "shadow cloakb bonusweapon basesprite shirt armor cloakf weapon offhandw hands helmet offhanda"
 
 #load basesprite /data/items/imperial/civil/bases_lictor.txt
 #load shadow /data/items/imperial/civil/shadow_lictor.txt

--- a/data/poses/merrow/troops.txt
+++ b/data/poses/merrow/troops.txt
@@ -1,9 +1,10 @@
 -- Normal
 #newpose
 #name "infantry"
-#renderorder "shadow bonusweapon basesprite shirt armor weapon offhandw helmet offhanda"
 #role "infantry"
 #role "scout"
+
+#renderorder "shadow bonusweapon basesprite shirt armor weapon offhandw hands helmet offhanda"
 
 #load basesprite /data/items/merrow/bases.txt
 #load hands /data/items/merrow/hands.txt

--- a/data/poses/monkey/vanaraelites.txt
+++ b/data/poses/monkey/vanaraelites.txt
@@ -148,10 +148,11 @@
 
 #baseitemslot feet 0
 
+#renderorder "shadow wings cloakb mount bag basesprite shirt legs strap armor cloakf quiver bonusweapon weapon offhandw hands hair helmet offhanda overlay overlay2"
+
 #load mount /data/items/monkey/vanara/mounted/bases_chariot.txt
 
 #load basesprite /data/items/monkey/vanara/mounted/bases.txt
-#load shadow /data/items/monkey/vanara/normal/shadow.txt
 
 #load hands /data/items/monkey/vanara/normal/hands.txt
 
@@ -168,6 +169,7 @@
 #load overlay /data/items/human/human_mounted/mountedoverlay.txt
 
 #load wings /data/items/monkey/vanara/mounted/wings.txt
+#load overlay2 /data/items/monkey/vanara/normal/overlay.txt
 
 #generateitem 1 shirt
 #command "#maxage 30"
@@ -185,6 +187,8 @@
 #basechance 0.125
 
 #baseitemslot feet 0
+
+#renderorder "shadow wings cloakb mount bag basesprite shirt legs strap armor cloakf quiver bonusweapon weapon offhandw hands hair helmet offhanda overlay overlay2"
 
 #load mount /data/items/monkey/vanara/mounted/bases_chariot.txt
 
@@ -207,6 +211,7 @@
 #load overlay /data/items/human/human_mounted/mountedoverlay.txt
 
 #load wings /data/items/monkey/vanara/mounted/wings.txt
+#load overlay2 /data/items/monkey/vanara/normal/overlay.txt
 
 #generateitem 1 bonusweapon
 #generateitem 1 shirt


### PR DESCRIPTION
* Fixes for the missing slots in renderorder
* This includes the probably-dates-back-to-Dom3 errors with Atlantian lobstermen and  standardbearers, so Atlantians are suddenly going to start producing those in entirely unreasonable quantities, which means I need to finally stop putting off modernizing Atlantian race definitions and adding themes to them