### PR TITLE
Restored previously removed #load handslots commands to clockworks

### DIFF
--- a/data/poses/hoburg/clockworktroops.txt
+++ b/data/poses/hoburg/clockworktroops.txt
@@ -95,6 +95,7 @@
 #load offhand /data/items/human/normal/towershields.txt 0 -5
 
 #load headslot /data/items/hoburg/clockwork/headslots_clockwork_medium.txt
+#load handslots /data/items/hoburg/clockwork/handslots_clockwork_medium.txt
 #load specialslot /data/items/hoburg/clockwork/specialslots_clockwork_medium.txt
 
 -- slots generated here are given through items; this pattern is used to be able to generate
@@ -140,6 +141,7 @@
 #load offhand /data/items/human/normal/towershields.txt 0 -5
 
 #load headslot /data/items/hoburg/clockwork/headslots_clockwork_medium.txt
+#load handslots /data/items/hoburg/clockwork/handslots_clockwork_medium.txt
 #load specialslot /data/items/hoburg/clockwork/specialslots_clockwork_medium.txt
 
 -- slots generated here are given through items; this pattern is used to be able to generate
@@ -186,6 +188,7 @@
 #load offhand /data/items/hoburg/clockwork/offhand_clockwork_heavy.txt
 #load offhand /data/items/hoburg/clockwork/shields_clockwork_heavy.txt
 
+#load handslots /data/items/hoburg/clockwork/handslots_clockwork_heavy.txt
 #load specialslot /data/items/hoburg/clockwork/specialslots_clockwork_heavy.txt
 
 -- these will generate some special items; some of them weapons like firespewers, some miscellaneous like supply bonuses
@@ -236,6 +239,7 @@
 #load offhand /data/items/hoburg/clockwork/offhand_clockwork_heavy.txt
 #load offhand /data/items/hoburg/clockwork/shields_clockwork_heavy.txt
 
+#load handslots /data/items/hoburg/clockwork/handslots_clockwork_heavy.txt
 #load specialslot /data/items/hoburg/clockwork/specialslots_clockwork_heavy.txt
 
 -- these will generate some special items; some of them weapons like firespewers, some miscellaneous like supply bonuses

--- a/data/poses/hoburg/clockworktroops_bronze.txt
+++ b/data/poses/hoburg/clockworktroops_bronze.txt
@@ -90,6 +90,7 @@
 #load offhand /data/items/human/normal/towershields.txt 0 -5
 
 #load headslot /data/items/hoburg/clockwork/headslots_clockwork_medium.txt
+#load handslots /data/items/hoburg/clockwork/handslots_clockwork_medium.txt
 #load specialslot /data/items/hoburg/clockwork/bronze/specialslots_clockwork_medium.txt
 
 -- slots generated here are given through items; this pattern is used to be able to generate
@@ -132,6 +133,7 @@
 #load offhand /data/items/human/normal/towershields.txt 0 -5
 
 #load headslot /data/items/hoburg/clockwork/headslots_clockwork_medium.txt
+#load handslots /data/items/hoburg/clockwork/handslots_clockwork_medium.txt
 #load specialslot /data/items/hoburg/clockwork/bronze/specialslots_clockwork_medium.txt
 
 -- slots generated here are given through items; this pattern is used to be able to generate
@@ -178,6 +180,7 @@
 #load offhand /data/items/hoburg/clockwork/bronze/offhand_clockwork_heavy.txt
 #load offhand /data/items/hoburg/clockwork/bronze/shields_clockwork_heavy.txt
 
+#load handslots /data/items/hoburg/clockwork/handslots_clockwork_heavy.txt
 #load specialslot /data/items/hoburg/clockwork/bronze/specialslots_clockwork_heavy.txt
 
 -- these will generate some special items; some of them weapons like firespewers, some miscellaneous like supply bonuses
@@ -228,6 +231,7 @@
 #load offhand /data/items/hoburg/clockwork/bronze/offhand_clockwork_colossal.txt
 #load offhand /data/items/hoburg/clockwork/bronze/shields_clockwork_heavy.txt
 
+#load handslots /data/items/hoburg/clockwork/handslots_clockwork_heavy.txt
 #load specialslot /data/items/hoburg/clockwork/bronze/specialslots_clockwork_heavy.txt
 
 -- these will generate some special items; some of them weapons like firespewers, some miscellaneous like supply bonuses

--- a/data/poses/hoburg/clockworktroops_oriental.txt
+++ b/data/poses/hoburg/clockworktroops_oriental.txt
@@ -85,6 +85,7 @@
 #load offhand /data/items/hoburg/clockwork/oriental/offhand_clockwork_medium.txt
 
 #load headslot /data/items/hoburg/clockwork/headslots_clockwork_medium.txt
+#load handslots /data/items/hoburg/clockwork/handslots_clockwork_medium.txt
 #load specialslot /data/items/hoburg/clockwork/oriental/specialslots_clockwork_medium.txt
 
 -- slots generated here are given through items; this pattern is used to be able to generate
@@ -124,6 +125,7 @@
 #load offhand /data/items/hoburg/clockwork/oriental/offhand_clockwork_medium.txt
 
 #load headslot /data/items/hoburg/clockwork/headslots_clockwork_medium.txt
+#load handslots /data/items/hoburg/clockwork/handslots_clockwork_medium.txt
 #load specialslot /data/items/hoburg/clockwork/oriental/specialslots_clockwork_medium.txt
 
 -- slots generated here are given through items; this pattern is used to be able to generate
@@ -169,6 +171,7 @@
 
 #load offhand /data/items/hoburg/clockwork/oriental/offhand_clockwork_heavy.txt
 
+#load handslots /data/items/hoburg/clockwork/handslots_clockwork_heavy.txt
 #load specialslot /data/items/hoburg/clockwork/oriental/specialslots_clockwork_heavy.txt
 
 #additionalweaponslot 1 specialslot
@@ -218,6 +221,7 @@
 
 #load offhand /data/items/hoburg/clockwork/oriental/offhand_clockwork_colossal.txt
 
+#load handslots /data/items/hoburg/clockwork/handslots_clockwork_medium.txt
 #load specialslot /data/items/hoburg/clockwork/oriental/specialslots_clockwork_heavy.txt
 
 #additionalweaponslot 1 specialslot


### PR DESCRIPTION
Turns out some specialslots items have #needs handslots tags, so the lists have to be loaded or otherwise an exception will be thrown when generating the nation.